### PR TITLE
feat: add Stellar RPC retry handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky"
@@ -46,6 +47,7 @@
     "prettier": "^3.0.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0",
-    "vite": "^6.3.0"
+    "vite": "^6.3.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       vite:
         specifier: ^6.3.0
         version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.6.0)(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3))
 
 packages:
 
@@ -1523,6 +1526,9 @@ packages:
   '@solana/web3.js@1.98.4':
     resolution: {integrity: sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stellar/freighter-api@3.1.0':
     resolution: {integrity: sha512-hsoZwAR/jNVIt8ee6aHYcRKVk09hDLHmsfK2nUfqHUo7LuHtuHI59y/mDyrT4bp/qlklGZNd2nr0hRJyjau8WQ==}
 
@@ -1560,6 +1566,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1568,6 +1577,9 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1641,6 +1653,35 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@wagmi/connectors@6.2.0':
     resolution: {integrity: sha512-2NfkbqhNWdjfibb4abRMrn7u6rPjEGolMfApXss6HCDVt9AW2oVC6k8Q5FouzpJezElxLJSagWz9FW1zaRlanA==}
@@ -1900,6 +1941,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
 
@@ -2061,6 +2106,10 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2413,6 +2462,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2445,6 +2497,9 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -2490,6 +2545,10 @@ packages:
 
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
@@ -3025,6 +3084,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
@@ -3244,6 +3306,9 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
@@ -3349,6 +3414,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3772,6 +3840,9 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   socket.io-client@4.8.3:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
@@ -3809,6 +3880,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
@@ -3823,6 +3897,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
@@ -3909,6 +3986,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -3916,6 +3996,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -4210,6 +4294,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
@@ -4249,6 +4374,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@6.2.0:
@@ -6513,6 +6643,8 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stellar/freighter-api@3.1.0':
     dependencies:
       buffer: 6.0.3
@@ -6579,6 +6711,11 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 25.6.0
@@ -6590,6 +6727,8 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -6681,6 +6820,47 @@ snapshots:
       vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.7':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.7':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.7':
+    dependencies:
+      '@vitest/utils': 4.1.7
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.7': {}
+
+  '@vitest/utils@4.1.7':
+    dependencies:
+      '@vitest/pretty-format': 4.1.7
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@wagmi/connectors@6.2.0(91d423540852604c41b9ade092e98f9b)':
     dependencies:
@@ -7417,6 +7597,8 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assertion-error@2.0.1: {}
+
   async-mutex@0.2.6:
     dependencies:
       tslib: 2.8.1
@@ -7577,6 +7759,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001788: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -7903,6 +8087,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -7956,6 +8142,10 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -8017,6 +8207,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource@2.0.2: {}
+
+  expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -8526,6 +8718,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
@@ -8819,6 +9015,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -8976,6 +9174,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -9433,6 +9633,8 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
+  siginfo@2.0.0: {}
+
   socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -9477,6 +9679,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
 
   stacktrace-parser@0.1.11:
@@ -9486,6 +9690,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stream-chain@2.2.5: {}
 
@@ -9594,12 +9800,16 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmpl@1.0.5: {}
 
@@ -9830,6 +10040,33 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
+  vitest@4.1.7(@types/node@25.6.0)(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(terser@5.46.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   vlq@1.0.1: {}
 
   wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(zod@4.3.6):
@@ -9907,6 +10144,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/src/components/StellarReceive.tsx
+++ b/src/components/StellarReceive.tsx
@@ -24,6 +24,7 @@ import { useStellarWallet } from '@/context/StellarWalletContext';
 import { CopyButton } from '@/components/CopyButton';
 import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
 import { STELLAR_NETWORK } from '@/config';
+import { isNetworkUnstableError, retryFetchJson, withRetry } from '@/lib/stellar/retry';
 
 const ANNOUNCER_CONTRACT = 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
 const REGISTRY_CONTRACT = 'CC2LAUCXYOPJ4DV4CYXNXYAXRDVOTMAWFF76W4WFD5OVQBD6TN4PYYJ5';
@@ -36,7 +37,7 @@ async function fetchAnnouncementEvents(
 
   try {
     let startLedger = 1;
-    const probeRes = await fetch(rpcUrl, {
+    const { data: probeData } = await retryFetchJson<{ error?: { message?: string } }>(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -50,7 +51,6 @@ async function fetchAnnouncementEvents(
         },
       }),
     });
-    const probeData = await probeRes.json();
 
     if (probeData.error?.message) {
       const match = probeData.error.message.match(/range:\s*(\d+)\s*-\s*(\d+)/);
@@ -78,13 +78,14 @@ async function fetchAnnouncementEvents(
         params.startLedger = startLedger;
       }
 
-      const res = await fetch(rpcUrl, {
+      const { data } = await retryFetchJson<{
+        result?: { events?: Record<string, unknown>[]; cursor?: string };
+      }>(rpcUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'getEvents', params }),
       });
 
-      const data = await res.json();
       const events = data.result?.events ?? [];
 
       for (const event of events) {
@@ -103,7 +104,8 @@ async function fetchAnnouncementEvents(
         if (!cursor) hasMore = false;
       }
     }
-  } catch {
+  } catch (err) {
+    if (isNetworkUnstableError(err)) throw err;
     // Events API may not be available
   }
 
@@ -150,6 +152,7 @@ function StellarStealthRow({
   const [withdrawing, setWithdrawing] = useState(false);
   const [withdrawHash, setWithdrawHash] = useState<string | null>(null);
   const [error, setError] = useState('');
+  const [canRetryWithdraw, setCanRetryWithdraw] = useState(false);
   const [showKey, setShowKey] = useState(false);
 
   const scalarHex = match.stealthPrivateScalar.toString(16).padStart(64, '0');
@@ -157,12 +160,13 @@ function StellarStealthRow({
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch(`${STELLAR_NETWORK.horizonUrl}/accounts/${match.stealthAddress}`);
+        const { response: res, data } = await retryFetchJson<{
+          balances?: { asset_type: string; balance: string }[];
+        }>(`${STELLAR_NETWORK.horizonUrl}/accounts/${match.stealthAddress}`);
         if (!res.ok) {
           setBalance('0');
           return;
         }
-        const data = await res.json();
         const xlm = data.balances?.find((b: { asset_type: string }) => b.asset_type === 'native');
         setBalance(xlm?.balance ?? '0');
       } catch {
@@ -176,15 +180,19 @@ function StellarStealthRow({
   const handleWithdraw = async () => {
     if (!dest) return;
     setError('');
+    setCanRetryWithdraw(false);
     setWithdrawing(true);
 
     try {
       const horizonUrl = STELLAR_NETWORK.horizonUrl;
       const networkPassphrase = STELLAR_NETWORK.networkPassphrase;
 
-      const res = await fetch(`${horizonUrl}/accounts/${match.stealthAddress}`);
+      const { response: res, data: account } = await retryFetchJson<{
+        sequence: string;
+        subentry_count?: number;
+        balances?: { asset_type: string; balance: string }[];
+      }>(`${horizonUrl}/accounts/${match.stealthAddress}`);
       if (!res.ok) throw new Error('Account not found');
-      const account = await res.json();
 
       const xlmBal = account.balances?.find(
         (b: { asset_type: string }) => b.asset_type === 'native',
@@ -213,13 +221,15 @@ function StellarStealthRow({
       const signatureBase64 = Buffer.from(signature).toString('base64');
       tx.addSignature(match.stealthAddress, signatureBase64);
 
-      const submitRes = await fetch(`${horizonUrl}/transactions`, {
+      const { response: submitRes, data: submitData } = await retryFetchJson<{
+        hash: string;
+        extras?: { result_codes?: { transaction?: string } };
+        title?: string;
+      }>(`${horizonUrl}/transactions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: `tx=${encodeURIComponent(tx.toXDR())}`,
       });
-
-      const submitData = await submitRes.json();
       if (!submitRes.ok) {
         throw new Error(
           submitData.extras?.result_codes?.transaction || submitData.title || 'Transaction failed',
@@ -229,7 +239,14 @@ function StellarStealthRow({
       setWithdrawHash(submitData.hash);
       onWithdrawn();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Withdraw failed');
+      setCanRetryWithdraw(isNetworkUnstableError(err));
+      setError(
+        isNetworkUnstableError(err)
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Withdraw failed',
+      );
     } finally {
       setWithdrawing(false);
     }
@@ -293,6 +310,14 @@ function StellarStealthRow({
       )}
 
       {error && <p className="text-xs text-error">{error}</p>}
+      {canRetryWithdraw && (
+        <button
+          onClick={handleWithdraw}
+          className="h-9 border border-error/30 font-heading text-[10px] font-semibold uppercase tracking-widest text-error transition-colors hover:bg-error/5"
+        >
+          Try Again
+        </button>
+      )}
 
       {withdrawHash && (
         <div className="flex items-center gap-2">
@@ -345,6 +370,7 @@ export function StellarReceive() {
   const [matched, setMatched] = useState<MatchedAnnouncement[]>([]);
   const [hasScanned, setHasScanned] = useState(false);
   const [error, setError] = useState('');
+  const [canRetryScan, setCanRetryScan] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [isRegSuccess, setIsRegSuccess] = useState(false);
   const [regHash, setRegHash] = useState<string | null>(null);
@@ -360,7 +386,7 @@ export function StellarReceive() {
         const soroban = new rpcMod.Server(STELLAR_NETWORK.rpcUrl);
         const networkPassphrase = STELLAR_NETWORK.networkPassphrase;
 
-        const accountResponse = await soroban.getAccount(address);
+        const accountResponse = await withRetry(() => soroban.getAccount(address));
         const sourceAccount = new Account(
           accountResponse.accountId(),
           accountResponse.sequenceNumber(),
@@ -378,7 +404,7 @@ export function StellarReceive() {
           .setTimeout(30)
           .build();
 
-        const simulated = await soroban.simulateTransaction(tx);
+        const simulated = await withRetry(() => soroban.simulateTransaction(tx));
         if (!('error' in simulated) && 'result' in simulated) {
           setIsAlreadyRegistered(true);
         }
@@ -415,7 +441,7 @@ export function StellarReceive() {
       const soroban = new rpcMod.Server(STELLAR_NETWORK.rpcUrl);
       const networkPassphrase = STELLAR_NETWORK.networkPassphrase;
 
-      const accountResponse = await soroban.getAccount(address);
+      const accountResponse = await withRetry(() => soroban.getAccount(address));
       const sourceAccount = new Account(
         accountResponse.accountId(),
         accountResponse.sequenceNumber(),
@@ -438,7 +464,7 @@ export function StellarReceive() {
         .setTimeout(30)
         .build();
 
-      const simulated = await soroban.simulateTransaction(tx);
+      const simulated = await withRetry(() => soroban.simulateTransaction(tx));
       if ('error' in simulated) {
         throw new Error((simulated as { error: string }).error || 'Simulation failed');
       }
@@ -448,8 +474,8 @@ export function StellarReceive() {
         .build();
 
       const signedXdr = await signTransaction(assembled.toXDR());
-      const response = await soroban.sendTransaction(
-        TransactionBuilder.fromXDR(signedXdr, networkPassphrase),
+      const response = await withRetry(() =>
+        soroban.sendTransaction(TransactionBuilder.fromXDR(signedXdr, networkPassphrase)),
       );
 
       if (response.status === 'ERROR') throw new Error('Transaction submission failed');
@@ -459,7 +485,7 @@ export function StellarReceive() {
       let attempts = 0;
       while (attempts < 30) {
         try {
-          const result = await soroban.getTransaction(response.hash);
+          const result = await withRetry(() => soroban.getTransaction(response.hash));
           if (result.status === 'NOT_FOUND') {
             attempts++;
             await new Promise((r) => setTimeout(r, 1000));
@@ -478,7 +504,13 @@ export function StellarReceive() {
         }
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Registration failed');
+      setError(
+        isNetworkUnstableError(err)
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Registration failed',
+      );
     } finally {
       setIsRegistering(false);
     }
@@ -488,6 +520,7 @@ export function StellarReceive() {
     if (!stellarKeys) return;
     setIsScanning(true);
     setError('');
+    setCanRetryScan(false);
     try {
       const announcements = await fetchAnnouncementEvents(
         STELLAR_NETWORK.rpcUrl,
@@ -502,7 +535,14 @@ export function StellarReceive() {
       setMatched(results);
       setHasScanned(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Scan failed');
+      setCanRetryScan(isNetworkUnstableError(err));
+      setError(
+        isNetworkUnstableError(err)
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Scan failed',
+      );
     } finally {
       setIsScanning(false);
     }
@@ -621,6 +661,14 @@ export function StellarReceive() {
           </div>
 
           {error && <p className="text-sm text-error">{error}</p>}
+          {canRetryScan && (
+            <button
+              onClick={scanPayments}
+              className="h-10 border border-error/30 font-heading text-[11px] font-semibold uppercase tracking-widest text-error transition-colors hover:bg-error/5"
+            >
+              Try Again
+            </button>
+          )}
 
           {matched.length > 0 && (
             <div className="flex flex-col gap-4">

--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -18,6 +18,7 @@ import { useStellarWallet } from '@/context/StellarWalletContext';
 import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
 import { STELLAR_NETWORK } from '@/config';
 import { CopyButton } from '@/components/CopyButton';
+import { isNetworkUnstableError, retryFetch, retryFetchJson, withRetry } from '@/lib/stellar/retry';
 
 const ANNOUNCER_CONTRACT = 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
 
@@ -26,6 +27,7 @@ export function StellarSend() {
   const [recipient, setRecipient] = useState('');
   const [amount, setAmount] = useState('');
   const [error, setError] = useState('');
+  const [canRetrySend, setCanRetrySend] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const [stealthResult, setStealthResult] = useState<{
     stealthAddress: string;
@@ -42,6 +44,7 @@ export function StellarSend() {
     }
 
     setError('');
+    setCanRetrySend(false);
     setIsPending(true);
 
     try {
@@ -59,14 +62,15 @@ export function StellarSend() {
       const horizonUrl = STELLAR_NETWORK.horizonUrl;
       const networkPassphrase = STELLAR_NETWORK.networkPassphrase;
 
-      const accountRes = await fetch(`${horizonUrl}/accounts/${address}`);
+      const { response: accountRes, data: accountData } = await retryFetchJson<{
+        sequence: string;
+      }>(`${horizonUrl}/accounts/${address}`);
       if (!accountRes.ok) throw new Error('Failed to load sender account');
-      const accountData = await accountRes.json();
       const sourceAccount = new Account(address, accountData.sequence);
 
-      const stealthExists = await fetch(`${horizonUrl}/accounts/${result.stealthAddress}`).then(
-        (r) => r.ok,
-      );
+      const stealthExists = await retryFetch(
+        `${horizonUrl}/accounts/${result.stealthAddress}`,
+      ).then((response) => response.ok);
 
       let classicTx;
       if (stealthExists) {
@@ -94,13 +98,15 @@ export function StellarSend() {
 
       const signedXdr = await signTransaction(classicTx.toXDR());
 
-      const submitRes = await fetch(`${horizonUrl}/transactions`, {
+      const { response: submitRes, data: submitData } = await retryFetchJson<{
+        hash: string;
+        extras?: { result_codes?: { transaction?: string } };
+        title?: string;
+      }>(`${horizonUrl}/transactions`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: `tx=${encodeURIComponent(signedXdr)}`,
       });
-
-      const submitData = await submitRes.json();
       if (!submitRes.ok) {
         throw new Error(
           submitData.extras?.result_codes?.transaction || submitData.title || 'Transaction failed',
@@ -115,8 +121,9 @@ export function StellarSend() {
         const soroban = new rpcMod.Server(STELLAR_NETWORK.rpcUrl);
         const announcerContract = new Contract(ANNOUNCER_CONTRACT);
 
-        const freshRes = await fetch(`${horizonUrl}/accounts/${address}`);
-        const freshData = await freshRes.json();
+        const { data: freshData } = await retryFetchJson<{ sequence: string }>(
+          `${horizonUrl}/accounts/${address}`,
+        );
         const freshAccount = new Account(address, freshData.sequence);
 
         const announceTx = new TransactionBuilder(freshAccount, { fee: '100', networkPassphrase })
@@ -132,7 +139,7 @@ export function StellarSend() {
           .setTimeout(30)
           .build();
 
-        const simulated = await soroban.simulateTransaction(announceTx);
+        const simulated = await withRetry(() => soroban.simulateTransaction(announceTx));
         if (!('error' in simulated)) {
           const assembled = rpcMod
             .assembleTransaction(
@@ -142,8 +149,8 @@ export function StellarSend() {
             .build();
 
           const signedAnnounce = await signTransaction(assembled.toXDR());
-          await soroban.sendTransaction(
-            TransactionBuilder.fromXDR(signedAnnounce, networkPassphrase),
+          await withRetry(() =>
+            soroban.sendTransaction(TransactionBuilder.fromXDR(signedAnnounce, networkPassphrase)),
           );
         }
       } catch {
@@ -152,7 +159,14 @@ export function StellarSend() {
 
       setIsSuccess(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed');
+      setCanRetrySend(isNetworkUnstableError(err));
+      setError(
+        isNetworkUnstableError(err)
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : 'Transaction failed',
+      );
     } finally {
       setIsPending(false);
     }
@@ -165,6 +179,7 @@ export function StellarSend() {
     setTxHash(null);
     setIsSuccess(false);
     setError('');
+    setCanRetrySend(false);
   };
 
   const handlePaste = async () => {
@@ -264,6 +279,14 @@ export function StellarSend() {
           </div>
 
           {error && <p className="text-sm text-error">{error}</p>}
+          {canRetrySend && (
+            <button
+              onClick={handleSend}
+              className="h-10 border border-error/30 font-heading text-[11px] font-semibold uppercase tracking-widest text-error transition-colors hover:bg-error/5"
+            >
+              Try Again
+            </button>
+          )}
 
           <button
             onClick={handleSend}

--- a/src/lib/stellar/retry.test.ts
+++ b/src/lib/stellar/retry.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { retryFetch, retryFetchJson, StellarRetryExhaustedError, withRetry } from './retry';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('stellar retry helpers', () => {
+  test('retries transient HTTP failures with exponential jittered delays and telemetry', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 502 }))
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    const delays: number[] = [];
+    const retryAttempts: number[] = [];
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await retryFetch('/rpc', undefined, {
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+      random: () => 0.5,
+      onRetry: ({ attempt }) => retryAttempts.push(attempt),
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(delays).toEqual([200, 400]);
+    expect(retryAttempts).toEqual([1, 2]);
+  });
+
+  test('does not retry non-retryable HTTP status responses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('unauthorized', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await retryFetch('/rpc');
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry malformed non-retryable HTTP error bodies', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('<html>unauthorized</html>', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await retryFetchJson('/rpc');
+
+    expect(result.response.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries JSON parse failures from overloaded endpoints', async () => {
+    const htmlResponse = new Response('<html>bad gateway</html>', { status: 200 });
+    const jsonResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(htmlResponse)
+      .mockResolvedValueOnce(jsonResponse);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await retryFetchJson<{ ok: boolean }>('/rpc', undefined, {
+      sleep: async () => {},
+    });
+
+    expect(result.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws StellarRetryExhaustedError with the last error after final attempt', async () => {
+    const lastError = new TypeError('network down');
+
+    await expect(
+      withRetry(
+        async () => {
+          throw lastError;
+        },
+        { attempts: 2, sleep: async () => {} },
+      ),
+    ).rejects.toMatchObject({
+      name: 'StellarRetryExhaustedError',
+      lastError,
+    } satisfies Partial<StellarRetryExhaustedError>);
+  });
+
+  test('respects an already-aborted signal without retrying', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fn = vi.fn();
+
+    await expect(withRetry(fn, { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/stellar/retry.ts
+++ b/src/lib/stellar/retry.ts
@@ -1,0 +1,160 @@
+export type RetryTelemetryEvent = {
+  attempt: number;
+  maxAttempts: number;
+  delayMs: number;
+  error: unknown;
+};
+
+export type RetryOptions = {
+  attempts?: number;
+  baseDelayMs?: number;
+  jitterRatio?: number;
+  signal?: AbortSignal;
+  onRetry?: (event: RetryTelemetryEvent) => void;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  random?: () => number;
+};
+
+export class StellarRetryExhaustedError extends Error {
+  readonly lastError: unknown;
+
+  constructor(lastError: unknown) {
+    super('Network unstable — try again.');
+    this.name = 'StellarRetryExhaustedError';
+    this.lastError = lastError;
+  }
+}
+
+class RetryableHttpError extends Error {
+  constructor(readonly response: Response) {
+    super(`Retryable HTTP ${response.status}`);
+    this.name = 'RetryableHttpError';
+  }
+}
+
+const RETRYABLE_STATUSES = new Set([408, 429, 502, 503, 504]);
+
+export async function withRetry<T>(fn: () => Promise<T>, opts: RetryOptions = {}): Promise<T> {
+  const attempts = opts.attempts ?? 4;
+  const baseDelayMs = opts.baseDelayMs ?? 200;
+  const jitterRatio = opts.jitterRatio ?? 0.25;
+  const sleep = opts.sleep ?? sleepWithAbort;
+  const random = opts.random ?? Math.random;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    throwIfAborted(opts.signal);
+
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableError(error)) {
+        throw error;
+      }
+      if (attempt >= attempts) {
+        throw new StellarRetryExhaustedError(lastError);
+      }
+
+      const delayMs = jitteredDelay(baseDelayMs, jitterRatio, attempt, random);
+      const event = { attempt, maxAttempts: attempts, delayMs, error };
+      opts.onRetry?.(event);
+      emitRetryEvent(event);
+      await sleep(delayMs, opts.signal);
+    }
+  }
+
+  throw new StellarRetryExhaustedError(lastError);
+}
+
+export async function retryFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  opts?: RetryOptions,
+): Promise<Response> {
+  return withRetry(async () => {
+    const response = await fetch(input, { ...init, signal: opts?.signal ?? init?.signal });
+    if (RETRYABLE_STATUSES.has(response.status)) {
+      throw new RetryableHttpError(response);
+    }
+    return response;
+  }, opts);
+}
+
+export async function retryFetchJson<T = unknown>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  opts?: RetryOptions,
+): Promise<{ response: Response; data: T }> {
+  return withRetry(async () => {
+    const response = await fetch(input, { ...init, signal: opts?.signal ?? init?.signal });
+    if (RETRYABLE_STATUSES.has(response.status)) {
+      throw new RetryableHttpError(response);
+    }
+
+    if (!response.ok) {
+      try {
+        return { response, data: (await response.json()) as T };
+      } catch {
+        return { response, data: undefined as T };
+      }
+    }
+
+    return { response, data: (await response.json()) as T };
+  }, opts);
+}
+
+export function isNetworkUnstableError(error: unknown): error is StellarRetryExhaustedError {
+  return error instanceof StellarRetryExhaustedError;
+}
+
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof RetryableHttpError) return true;
+  if (error instanceof SyntaxError) return true;
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  if (!(error instanceof Error)) return false;
+
+  return (
+    error.name === 'AbortError' ||
+    error.name === 'TimeoutError' ||
+    error.name === 'TypeError' ||
+    error.message.toLowerCase().includes('network')
+  );
+}
+
+function jitteredDelay(
+  baseDelayMs: number,
+  jitterRatio: number,
+  attempt: number,
+  random: () => number,
+): number {
+  const rawDelay = baseDelayMs * 2 ** (attempt - 1);
+  const jitter = rawDelay * jitterRatio * (random() * 2 - 1);
+  return Math.max(0, Math.round(rawDelay + jitter));
+}
+
+function emitRetryEvent(event: RetryTelemetryEvent) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('stellar:retry', { detail: event }));
+}
+
+async function sleepWithAbort(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    throwIfAborted(signal);
+    const timeout = globalThis.setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        globalThis.clearTimeout(timeout);
+        reject(new DOMException('The operation was aborted.', 'AbortError'));
+      },
+      { once: true },
+    );
+  });
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException('The operation was aborted.', 'AbortError');
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared Stellar retry helper with exponential backoff, ±25% jitter, retry telemetry, AbortSignal support, and StellarRetryExhaustedError
- Wrap Stellar Horizon/Soroban fetches and Soroban SDK calls in retry handling
- Surface exhausted network retries as "Network unstable — try again." with retry buttons in Stellar send/receive flows
- Add Vitest unit coverage for transient HTTP retries, non-retryable 4xx behavior, JSON parse retries, exhausted retries, and aborted signals

Closes #2

## Validation
- npx prettier --check .
- npx vitest run
- npx tsc --noEmit
- npx vite build
- npx pnpm@10 test
- npx pnpm@10 build
- git diff --check

Note: Vite build emits existing dependency chunk/PURE annotation warnings, but exits successfully.