### PR TITLE
feat(stellar): add payment link generation and consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 reference/
 *.local
 package-lock.json
+playwright-report/
+test-results/

--- a/e2e/payment-link.spec.ts
+++ b/e2e/payment-link.spec.ts
@@ -1,20 +1,34 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Stellar Payment Link', () => {
+  test.beforeEach(async ({ context }) => {
+    // Mock Freighter API so the app thinks a wallet is installed and connected
+    await context.addInitScript(() => {
+      (window as any).freighter = {
+        isConnected: () => Promise.resolve({ isConnected: true }),
+        getAddress: () => Promise.resolve({ address: 'GATTESTADDRESSYOURSFREIGHTER123456789' }),
+        requestAccess: () => Promise.resolve(),
+      };
+      (window as any).freighterApi = (window as any).freighter; // Some versions use freighterApi
+    });
+  });
+
   test('should generate a link, pre-fill the send form, and disable inputs', async ({ page, context }) => {
     // 1. Go to Receive page
     await page.goto('/receive');
-
-    // We might need to mock the wallet connection if it's required to see the form.
-    // For this test, we assume the UI handles an unconnected state or we can connect a mock wallet.
-    // Since we don't have a mock wallet setup easily available, we'll navigate directly to the /pay route
-    // with some parameters to test the receiving side, which is the core of the validation.
+    await page.locator('select').selectOption('stellar');
 
     // 2. Open generated link in a new context
     const testUrl = '/pay?to=st:xlm:test_meta_address&amount=15.5&memo=TestMemo&exp=' + (Math.floor(Date.now() / 1000) + 3600);
     
     const newPage = await context.newPage();
     await newPage.goto(testUrl);
+
+    // Switch to Stellar network
+    await newPage.locator('select').selectOption('stellar');
+    
+    // Click Connect Freighter
+    await newPage.click('text=Connect Freighter');
 
     // 3. Verify Send page pre-filled inputs
     const recipientInput = newPage.locator('input[placeholder="st:xlm:..."]');
@@ -35,6 +49,12 @@ test.describe('Stellar Payment Link', () => {
     const testUrl = `/pay?to=st:xlm:test_meta_address&amount=10&exp=${expiredExp}`;
     
     await page.goto(testUrl);
+
+    // Switch to Stellar network
+    await page.locator('select').selectOption('stellar');
+
+    // Click Connect Freighter
+    await page.click('text=Connect Freighter');
 
     // Check for error message
     const errorText = page.locator('text=This payment link has expired');

--- a/e2e/payment-link.spec.ts
+++ b/e2e/payment-link.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Stellar Payment Link', () => {
+  test('should generate a link, pre-fill the send form, and disable inputs', async ({ page, context }) => {
+    // 1. Go to Receive page
+    await page.goto('/receive');
+
+    // We might need to mock the wallet connection if it's required to see the form.
+    // For this test, we assume the UI handles an unconnected state or we can connect a mock wallet.
+    // Since we don't have a mock wallet setup easily available, we'll navigate directly to the /pay route
+    // with some parameters to test the receiving side, which is the core of the validation.
+
+    // 2. Open generated link in a new context
+    const testUrl = '/pay?to=st:xlm:test_meta_address&amount=15.5&memo=TestMemo&exp=' + (Math.floor(Date.now() / 1000) + 3600);
+    
+    const newPage = await context.newPage();
+    await newPage.goto(testUrl);
+
+    // 3. Verify Send page pre-filled inputs
+    const recipientInput = newPage.locator('input[placeholder="st:xlm:..."]');
+    await expect(recipientInput).toHaveValue('st:xlm:test_meta_address');
+    await expect(recipientInput).toBeDisabled();
+
+    const amountInput = newPage.locator('input[placeholder="0.0"]');
+    await expect(amountInput).toHaveValue('15.5');
+    await expect(amountInput).toBeDisabled();
+
+    const memoInput = newPage.locator('input[placeholder="e.g. Coffee"]');
+    await expect(memoInput).toHaveValue('TestMemo');
+    await expect(memoInput).toBeDisabled();
+  });
+
+  test('should show expiration error and disable submit for expired link', async ({ page }) => {
+    const expiredExp = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+    const testUrl = `/pay?to=st:xlm:test_meta_address&amount=10&exp=${expiredExp}`;
+    
+    await page.goto(testUrl);
+
+    // Check for error message
+    const errorText = page.locator('text=This payment link has expired');
+    await expect(errorText).toBeVisible();
+
+    // The recipient and amount should still be pre-filled and disabled
+    const recipientInput = page.locator('input[placeholder="st:xlm:..."]');
+    await expect(recipientInput).toHaveValue('st:xlm:test_meta_address');
+    await expect(recipientInput).toBeDisabled();
+
+    // Verify submit button is disabled
+    const submitButton = page.locator('button:has-text("Send Privately")');
+    // Button might also say "Confirm in wallet..." but the text says "Send Privately" initially
+    await expect(submitButton).toBeDisabled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@wraith-protocol/sdk": "^1.4.5",
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^8",
     "@storybook/addon-essentials": "^8",
     "@storybook/addon-interactions": "^8",
@@ -48,6 +50,7 @@
     "@storybook/test": "^8.6.18",
     "@storybook/test-runner": "^0.19.1",
     "@types/jest-image-snapshot": "^6.4.1",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ export function App() {
         <Routes>
           <Route path="/send" element={<Send />} />
           <Route path="/receive" element={<Receive />} />
+          <Route path="/pay" element={<Send />} />
           <Route path="*" element={<Navigate to="/send" replace />} />
         </Routes>
       </main>

--- a/src/components/StellarPaymentLink.tsx
+++ b/src/components/StellarPaymentLink.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { CopyButton } from '@/components/CopyButton';
+
+export interface StellarPaymentLinkProps {
+  metaAddress: string;
+}
+
+export function StellarPaymentLink({ metaAddress }: StellarPaymentLinkProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [amount, setAmount] = useState('');
+  const [memo, setMemo] = useState('');
+  const [expiresIn, setExpiresIn] = useState('24h');
+  const [generatedUrl, setGeneratedUrl] = useState<string | null>(null);
+
+  const handleGenerate = () => {
+    const url = new URL(window.location.origin + '/pay');
+    url.searchParams.set('to', metaAddress);
+    if (amount) url.searchParams.set('amount', amount);
+    if (memo) url.searchParams.set('memo', memo);
+
+    let expSecs = 0;
+    const nowSecs = Math.floor(Date.now() / 1000);
+    if (expiresIn === '1h') expSecs = nowSecs + 3600;
+    else if (expiresIn === '24h') expSecs = nowSecs + 86400;
+    else if (expiresIn === '7d') expSecs = nowSecs + 7 * 86400;
+
+    if (expSecs > 0) {
+      url.searchParams.set('exp', expSecs.toString());
+    }
+
+    setGeneratedUrl(url.toString());
+  };
+
+  return (
+    <div className="border border-outline-variant bg-surface-container p-5">
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          Receive Payment
+        </span>
+        <button
+          onClick={() => setShowForm(!showForm)}
+          className="font-mono text-[10px] font-semibold uppercase tracking-widest text-primary transition-colors hover:brightness-110"
+        >
+          {showForm ? 'Close' : 'Generate Payment Link'}
+        </button>
+      </div>
+
+      {showForm && (
+        <div className="mt-4 flex flex-col gap-4 border-t border-outline-variant/30 pt-4">
+          <div className="flex flex-col gap-1.5">
+            <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Amount (optional)
+            </label>
+            <input
+              type="text"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              placeholder="0.0"
+              className="h-10 border border-outline-variant bg-surface px-3 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Memo (optional)
+            </label>
+            <input
+              type="text"
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              placeholder="e.g. Coffee"
+              maxLength={28}
+              className="h-10 border border-outline-variant bg-surface px-3 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Expires In
+            </label>
+            <select
+              value={expiresIn}
+              onChange={(e) => setExpiresIn(e.target.value)}
+              className="h-10 border border-outline-variant bg-surface px-3 font-mono text-sm text-primary focus:border-primary"
+            >
+              <option value="1h">1 hour</option>
+              <option value="24h">24 hours</option>
+              <option value="7d">7 days</option>
+              <option value="never">Never</option>
+            </select>
+          </div>
+          <button
+            onClick={handleGenerate}
+            className="mt-2 h-10 w-full bg-primary font-heading text-[11px] font-semibold uppercase tracking-widest text-surface transition-colors hover:brightness-110"
+          >
+            Generate Link
+          </button>
+        </div>
+      )}
+
+      {showForm && generatedUrl && (
+        <div className="mt-6 flex flex-col items-center gap-4 border-t border-outline-variant/30 pt-6">
+          <div className="rounded-lg bg-white p-3">
+            <QRCodeSVG value={generatedUrl} size={160} />
+          </div>
+          <div className="flex w-full items-center gap-2 rounded bg-surface p-2 border border-outline-variant">
+            <code className="block flex-1 truncate font-mono text-[10px] text-primary">
+              {generatedUrl}
+            </code>
+            <CopyButton text={generatedUrl} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/StellarReceiveView.tsx
+++ b/src/components/StellarReceiveView.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { stellarTxUrl } from '@/lib/explorer';
 import { CopyButton } from '@/components/CopyButton';
+import { StellarPaymentLink } from '@/components/StellarPaymentLink';
 
 export interface StellarReceiveViewProps {
   isConnected: boolean;
@@ -133,6 +134,8 @@ export function StellarReceiveView({
               </div>
             )}
           </div>
+
+          <StellarPaymentLink metaAddress={metaAddress} />
 
           <div className="flex items-center justify-between">
             <button

--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   TransactionBuilder,
   Account,
@@ -8,6 +9,7 @@ import {
   Address,
   Operation,
   Asset,
+  Memo,
 } from '@stellar/stellar-sdk';
 import {
   generateStealthAddress,
@@ -65,9 +67,16 @@ function validateAmount(value: string) {
 }
 
 export function StellarSend() {
+  const [searchParams] = useSearchParams();
+  const paramTo = searchParams.get('to');
+  const paramAmount = searchParams.get('amount');
+  const paramMemo = searchParams.get('memo');
+  const paramExp = searchParams.get('exp');
+
   const { address, isConnected, signTransaction } = useStellarWallet();
-  const [recipient, setRecipient] = useState('');
-  const [amount, setAmount] = useState('');
+  const [recipient, setRecipient] = useState(paramTo || '');
+  const [amount, setAmount] = useState(paramAmount || '');
+  const [memo, setMemo] = useState(paramMemo || '');
   const [error, setError] = useState('');
   const [touched, setTouched] = useState({ recipient: false, amount: false });
   const [submitAttempted, setSubmitAttempted] = useState(false);
@@ -75,6 +84,18 @@ export function StellarSend() {
   const [isBalanceLoading, setIsBalanceLoading] = useState(false);
   const [balanceLookupError, setBalanceLookupError] = useState('');
   const [isPending, setIsPending] = useState(false);
+  const [isExpired, setIsExpired] = useState(false);
+
+  useEffect(() => {
+    if (paramExp) {
+      const expSecs = parseInt(paramExp, 10);
+      if (!isNaN(expSecs) && expSecs * 1000 < Date.now()) {
+        setIsExpired(true);
+        setError('This payment link has expired');
+      }
+    }
+  }, [paramExp]);
+
   const [stealthResult, setStealthResult] = useState<{
     stealthAddress: string;
     ephemeralPubKey: Uint8Array;
@@ -105,7 +126,8 @@ export function StellarSend() {
     !validationError &&
     !isAwaitingBalance &&
     !isBalanceLoading &&
-    !isPending;
+    !isPending &&
+    !isExpired;
 
   useEffect(() => {
     setSourceBalance(null);
@@ -183,29 +205,32 @@ export function StellarSend() {
         (r) => r.ok,
       );
 
-      let classicTx;
+      let builder = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase });
+
       if (stealthExists) {
-        classicTx = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase })
-          .addOperation(
-            Operation.payment({
-              destination: result.stealthAddress,
-              asset: Asset.native(),
-              amount: amountValue,
-            }),
-          )
-          .setTimeout(30)
-          .build();
+        builder = builder.addOperation(
+          Operation.payment({
+            destination: result.stealthAddress,
+            asset: Asset.native(),
+            amount: amountValue,
+          }),
+        );
       } else {
-        classicTx = new TransactionBuilder(sourceAccount, { fee: '100', networkPassphrase })
-          .addOperation(
-            Operation.createAccount({
-              destination: result.stealthAddress,
-              startingBalance: amountValue,
-            }),
-          )
-          .setTimeout(30)
-          .build();
+        builder = builder.addOperation(
+          Operation.createAccount({
+            destination: result.stealthAddress,
+            startingBalance: amountValue,
+          }),
+        );
       }
+
+      builder = builder.setTimeout(30);
+
+      if (memo) {
+        builder = builder.addMemo(Memo.text(memo));
+      }
+
+      const classicTx = builder.build();
 
       const signedXdr = await signTransaction(classicTx.toXDR());
 
@@ -271,15 +296,18 @@ export function StellarSend() {
     } finally {
       setIsPending(false);
     }
-  }, [address, amountValue, canSubmit, metaAddress, signTransaction, validationError]);
+  }, [address, amountValue, canSubmit, metaAddress, memo, signTransaction, validationError]);
 
   const reset = () => {
-    setRecipient('');
-    setAmount('');
+    setRecipient(paramTo || '');
+    setAmount(paramAmount || '');
+    setMemo(paramMemo || '');
     setStealthResult(null);
     setTxHash(null);
     setIsSuccess(false);
-    setError('');
+    if (!isExpired) {
+      setError('');
+    }
     setTouched({ recipient: false, amount: false });
     setSubmitAttempted(false);
     setSourceBalance(null);
@@ -328,6 +356,12 @@ export function StellarSend() {
       onPaste={handlePaste}
       onSend={handleSend}
       onReset={reset}
+      memo={memo}
+      onMemoChange={setMemo}
+      isExpired={isExpired}
+      paramTo={!!paramTo}
+      paramAmount={!!paramAmount}
+      paramMemo={!!paramMemo}
     />
   );
 }

--- a/src/components/StellarSendView.tsx
+++ b/src/components/StellarSendView.tsx
@@ -25,6 +25,13 @@ export interface StellarSendViewProps {
   onPaste: () => void;
   onSend: () => void;
   onReset: () => void;
+  // Extra optional props for payment-link / memo support
+  memo?: string;
+  onMemoChange?: (value: string) => void;
+  isExpired?: boolean;
+  paramTo?: boolean;
+  paramAmount?: boolean;
+  paramMemo?: boolean;
 }
 
 export function StellarSendView({
@@ -51,6 +58,13 @@ export function StellarSendView({
   onPaste,
   onSend,
   onReset,
+  // Extra props destructuring with default fallbacks
+  memo = '',
+  onMemoChange,
+  isExpired = false,
+  paramTo = false,
+  paramAmount = false,
+  paramMemo = false,
 }: StellarSendViewProps) {
   if (!isConnected) {
     return (
@@ -99,14 +113,17 @@ export function StellarSendView({
                 aria-invalid={!!recipientError}
                 aria-describedby="stellar-recipient-error"
                 placeholder="st:xlm:..."
-                className="h-12 w-full border border-outline-variant bg-surface px-4 pr-20 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
+                disabled={paramTo || isExpired}
+                className="h-12 w-full border border-outline-variant bg-surface px-4 pr-20 font-mono text-sm text-primary placeholder:text-outline focus:border-primary disabled:opacity-50"
               />
-              <button
-                onClick={onPaste}
-                className="absolute right-3 top-1/2 -translate-y-1/2 font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
-              >
-                Paste
-              </button>
+              {!paramTo && !isExpired && (
+                <button
+                  onClick={onPaste}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
+                >
+                  Paste
+                </button>
+              )}
             </div>
             <p
               id="stellar-recipient-error"
@@ -131,7 +148,8 @@ export function StellarSendView({
                 aria-invalid={amountInvalid}
                 aria-describedby="stellar-amount-error stellar-balance-error"
                 placeholder="0.0"
-                className="h-12 w-full border border-outline-variant bg-surface px-4 pr-16 font-heading text-2xl text-primary placeholder:text-outline focus:border-primary"
+                disabled={paramAmount || isExpired}
+                className="h-12 w-full border border-outline-variant bg-surface px-4 pr-16 font-heading text-2xl text-primary placeholder:text-outline focus:border-primary disabled:opacity-50"
               />
               <span className="absolute right-3 top-1/2 -translate-y-1/2 font-mono text-xs text-outline">
                 XLM
@@ -140,6 +158,22 @@ export function StellarSendView({
             <p id="stellar-amount-error" className="min-h-5 text-xs text-error" aria-live="polite">
               {showAmountError && amountError ? amountError : ' '}
             </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Memo (optional)
+            </label>
+            <input
+              id="stellar-memo"
+              type="text"
+              value={memo}
+              onChange={(e) => onMemoChange?.(e.target.value)}
+              placeholder="e.g. Coffee"
+              maxLength={28}
+              disabled={paramMemo || isExpired}
+              className="h-12 w-full border border-outline-variant bg-surface px-4 font-mono text-sm text-primary placeholder:text-outline focus:border-primary disabled:opacity-50"
+            />
           </div>
 
           <div className="flex flex-col gap-2 border-t border-outline-variant/30 pt-4">


### PR DESCRIPTION
## Title
feat(stellar): add payment link generation and consumption

## Description
This PR introduces the ability to generate and consume payment links on the Stellar network, solving the UX friction of sharing raw meta-addresses manually. Senders can now share a URL (or QR code) that deep-links directly into a pre-filled Send page.

### Features
- **Generate Payment Link**: Added a new UI section to `StellarReceive` (visible after deriving keys) that allows recipients to generate a payment URL and QR code.
- **Form Options**: Senders can optionally pre-fill an `amount`, a `memo`, and an `expires-at` duration (defaults to 24h).
- **Consumption Route (`/pay`)**: Added a `/pay` route that loads the Send page and populates the inputs based on the URL parameters.
- **Validation & Tamper Resistance**:
  - The Send form validates the `exp` timestamp. If the link is expired, it displays an error and disables the submit button.
  - Pre-filled inputs (recipient, amount, memo) are disabled on the Send page to ensure the sender sends exactly what was requested without accidental modification.
- **Memo Support**: Added native support for the `memo` field in `StellarSend` to append to the `TransactionBuilder`.
- **E2E Testing**: Includes a Playwright test suite (`e2e/payment-link.spec.ts`) validating the pre-fill behavior and expiration logic.

### Design Decisions & Trade-offs
- **URL Parameter Signing**: Decided to skip signing URL parameters with the recipient's spending key for this iteration. *Rationale*: Keeps URLs short and simple. Since the sender always reviews the final transaction details in their wallet before signing, any tampering with the URL only alters the pre-filled form data, not the final authorized transaction.
- **.wraith Name Lookup**: Defaulted to using the raw meta-address for now, as on-chain `.wraith` name resolution context is not yet fully available for the Stellar chain in this codebase.

## Screenshot
<img width="929" height="650" alt="Screenshot from 2026-05-29 05-14-45" src="https://github.com/user-attachments/assets/b60df8e4-306e-4c1e-9cc3-4a42c6d7770a" />


### Testing
- [x] Tested generating a link with combinations of amount, memo, and expiration.
- [x] Verified QR code rendering.
- [x] Verified `/pay` deep-link correctly pre-fills and locks down form inputs.
- [x] Verified expired links are properly rejected.

closes #7 