### PR TITLE
feat: persist Freighter sessions

### DIFF
--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -40,19 +40,64 @@ function HorizenButton() {
 }
 
 function FreighterButton() {
-  const { address, isConnected, connect, disconnect } = useStellarWallet();
+  const {
+    address,
+    isConnected,
+    status,
+    statusMessage,
+    preferredNetwork,
+    setPreferredNetwork,
+    connect,
+    disconnect,
+    retryInstallDetection,
+  } = useStellarWallet();
+
+  const handleInstall = () => {
+    window.open('https://www.freighter.app/', '_blank', 'noopener,noreferrer');
+    retryInstallDetection();
+  };
 
   if (isConnected && address) {
     return (
-      <button onClick={disconnect} className={btnConnected}>
-        {address.slice(0, 4)}...{address.slice(-4)}
+      <div className="flex items-center gap-2">
+        <select
+          value={preferredNetwork}
+          onChange={(event) =>
+            setPreferredNetwork(event.target.value as 'testnet' | 'futurenet' | 'mainnet')
+          }
+          className="h-8 border border-outline-variant bg-transparent px-2 font-mono text-[10px] uppercase tracking-widest text-primary sm:h-9"
+          aria-label="Preferred Stellar network"
+        >
+          <option value="testnet">Testnet</option>
+          <option value="futurenet">Futurenet</option>
+          <option value="mainnet">Mainnet</option>
+        </select>
+        <button onClick={disconnect} className={btnConnected}>
+          {address.slice(0, 4)}...{address.slice(-4)}
+        </button>
+      </div>
+    );
+  }
+
+  if (status === 'not_installed') {
+    return (
+      <button onClick={handleInstall} title={statusMessage} className={btnBase}>
+        Install Freighter
+      </button>
+    );
+  }
+
+  if (status === 'not_allowed') {
+    return (
+      <button onClick={connect} title={statusMessage} className={btnBase}>
+        Approve Freighter
       </button>
     );
   }
 
   return (
-    <button onClick={connect} className={btnBase}>
-      Connect Freighter
+    <button onClick={connect} title={statusMessage || undefined} className={btnBase}>
+      {status === 'checking' ? 'Checking...' : 'Connect Freighter'}
     </button>
   );
 }

--- a/src/context/StealthKeysContext.tsx
+++ b/src/context/StealthKeysContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import type { StealthKeys as EVMStealthKeys } from '@wraith-protocol/sdk/chains/evm';
 import type { StealthKeys as StellarStealthKeys } from '@wraith-protocol/sdk/chains/stellar';
 import type { StealthKeys as SolanaStealthKeys } from '@wraith-protocol/sdk/chains/solana';
@@ -47,6 +47,11 @@ export function StealthKeysProvider({ children }: { children: React.ReactNode })
     setStellarKeys(null);
     setStellarMetaAddress(null);
   }, []);
+
+  useEffect(() => {
+    window.addEventListener('stellar:clear-stealth-keys', clearStellar);
+    return () => window.removeEventListener('stellar:clear-stealth-keys', clearStellar);
+  }, [clearStellar]);
   const clearSolana = useCallback(() => {
     setSolanaKeys(null);
     setSolanaMetaAddress(null);

--- a/src/context/StellarWalletContext.tsx
+++ b/src/context/StellarWalletContext.tsx
@@ -1,41 +1,231 @@
 import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 import { STELLAR_NETWORK } from '@/config';
 
+type FreighterStatus = 'checking' | 'ready' | 'not_installed' | 'not_allowed' | 'error';
+type StellarNetworkPreference = 'testnet' | 'futurenet' | 'mainnet';
+
 interface StellarWalletContextValue {
   address: string | null;
   isConnected: boolean;
+  status: FreighterStatus;
+  statusMessage: string;
+  network: string | null;
+  networkPassphrase: string | null;
+  preferredNetwork: StellarNetworkPreference;
+  setPreferredNetwork: (network: StellarNetworkPreference) => void;
   connect: () => Promise<void>;
   disconnect: () => void;
+  retryInstallDetection: () => void;
   signMessage: (message: string) => Promise<Uint8Array>;
   signTransaction: (xdr: string) => Promise<string>;
 }
 
 const StellarWalletContext = createContext<StellarWalletContextValue | null>(null);
+const STORAGE_KEY = 'wraith:stellar:preferred-network';
+const CHANNEL_NAME = 'wraith:stellar-wallet';
+
+type BroadcastMessage =
+  | {
+      type: 'connected';
+      address: string | null;
+      network: string | null;
+      networkPassphrase: string | null;
+    }
+  | { type: 'disconnected' }
+  | { type: 'network'; network: string | null; networkPassphrase: string | null }
+  | { type: 'preferred-network'; preferredNetwork: StellarNetworkPreference };
+
+type WalletChangePayload = {
+  address: string;
+  network: string;
+  networkPassphrase: string;
+};
+
+type WalletWatcher = {
+  watch: (callback: (payload: WalletChangePayload) => void) => void;
+  stop: () => void;
+};
+
+function getInitialPreferredNetwork(): StellarNetworkPreference {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'testnet' || stored === 'futurenet' || stored === 'mainnet') return stored;
+  return 'testnet';
+}
+
+function clearStellarStealthKeys() {
+  window.dispatchEvent(new Event('stellar:clear-stealth-keys'));
+}
+
+function networkToPreference(network: string): StellarNetworkPreference | null {
+  const normalized = network.toLowerCase();
+  if (normalized.includes('test')) return 'testnet';
+  if (normalized.includes('future')) return 'futurenet';
+  if (normalized.includes('public') || normalized.includes('main')) return 'mainnet';
+  return null;
+}
 
 export function StellarWalletProvider({ children }: { children: React.ReactNode }) {
   const [address, setAddress] = useState<string | null>(null);
+  const [status, setStatus] = useState<FreighterStatus>('checking');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [network, setNetwork] = useState<string | null>(null);
+  const [networkPassphrase, setNetworkPassphrase] = useState<string | null>(null);
+  const [preferredNetwork, setPreferredNetworkState] = useState<StellarNetworkPreference>(
+    getInitialPreferredNetwork,
+  );
 
   const isConnected = !!address;
 
+  const broadcast = useCallback((message: BroadcastMessage) => {
+    if (!('BroadcastChannel' in window)) return;
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channel.postMessage(message);
+    channel.close();
+  }, []);
+
+  const setPreferredNetwork = useCallback(
+    (nextNetwork: StellarNetworkPreference) => {
+      localStorage.setItem(STORAGE_KEY, nextNetwork);
+      setPreferredNetworkState(nextNetwork);
+      broadcast({ type: 'preferred-network', preferredNetwork: nextNetwork });
+    },
+    [broadcast],
+  );
+
+  const restoreIfAllowed = useCallback(async () => {
+    try {
+      setStatus('checking');
+      const freighter = await import('@stellar/freighter-api');
+      const { isConnected: connected } = await freighter.isConnected();
+      if (!connected) {
+        setStatus('not_installed');
+        setStatusMessage('Install Freighter to connect a Stellar wallet.');
+        return false;
+      }
+
+      const { isAllowed: allowed } = await freighter.isAllowed();
+      if (!allowed) {
+        setStatus('not_allowed');
+        setStatusMessage('Approve this site in Freighter to reconnect.');
+        return false;
+      }
+
+      const { address: addr } = await freighter.getAddress();
+      const details = await freighter.getNetworkDetails();
+      const nextPreference = details.network ? networkToPreference(details.network) : null;
+      if (nextPreference) {
+        localStorage.setItem(STORAGE_KEY, nextPreference);
+        setPreferredNetworkState(nextPreference);
+      }
+
+      setNetwork(details.network || null);
+      setNetworkPassphrase(details.networkPassphrase || null);
+
+      if (!addr) {
+        setStatus('not_allowed');
+        setStatusMessage('Approve this site in Freighter to reconnect.');
+        return false;
+      }
+
+      setAddress(addr);
+      setStatus('ready');
+      setStatusMessage('');
+      broadcast({
+        type: 'connected',
+        address: addr,
+        network: details.network || null,
+        networkPassphrase: details.networkPassphrase || null,
+      });
+      return true;
+    } catch {
+      setStatus('not_installed');
+      setStatusMessage('Install Freighter to connect a Stellar wallet.');
+      return false;
+    }
+  }, [broadcast]);
+
   useEffect(() => {
+    void restoreIfAllowed();
+  }, [restoreIfAllowed]);
+
+  useEffect(() => {
+    if (!('BroadcastChannel' in window)) return;
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    channel.onmessage = (event: MessageEvent<BroadcastMessage>) => {
+      const message = event.data;
+      if (message.type === 'connected') {
+        setAddress(message.address);
+        setNetwork(message.network);
+        setNetworkPassphrase(message.networkPassphrase);
+        setStatus(message.address ? 'ready' : 'not_allowed');
+        setStatusMessage('');
+      }
+      if (message.type === 'disconnected') {
+        setAddress(null);
+        clearStellarStealthKeys();
+      }
+      if (message.type === 'network') {
+        setNetwork(message.network);
+        setNetworkPassphrase(message.networkPassphrase);
+        clearStellarStealthKeys();
+      }
+      if (message.type === 'preferred-network') {
+        setPreferredNetworkState(message.preferredNetwork);
+      }
+    };
+    return () => channel.close();
+  }, []);
+
+  useEffect(() => {
+    let watcher: WalletWatcher | null = null;
+
     (async () => {
       try {
         const freighter = await import('@stellar/freighter-api');
-        const { isConnected: connected } = await freighter.isConnected();
-        if (connected) {
-          const { address: addr } = await freighter.getAddress();
-          if (addr) setAddress(addr);
-        }
+        watcher = new freighter.WatchWalletChanges(2000) as WalletWatcher;
+        watcher.watch(
+          ({ address: nextAddress, network: nextNetwork, networkPassphrase: nextPassphrase }) => {
+            if (nextAddress && nextAddress !== address) {
+              setAddress(nextAddress);
+              clearStellarStealthKeys();
+              broadcast({
+                type: 'connected',
+                address: nextAddress,
+                network: nextNetwork || null,
+                networkPassphrase: nextPassphrase || null,
+              });
+            }
+            if (nextNetwork && nextNetwork !== network) {
+              setNetwork(nextNetwork);
+              setNetworkPassphrase(nextPassphrase || null);
+              const nextPreference = networkToPreference(nextNetwork);
+              if (nextPreference) {
+                localStorage.setItem(STORAGE_KEY, nextPreference);
+                setPreferredNetworkState(nextPreference);
+              }
+              clearStellarStealthKeys();
+              broadcast({
+                type: 'network',
+                network: nextNetwork,
+                networkPassphrase: nextPassphrase || null,
+              });
+            }
+          },
+        );
       } catch {
-        // Freighter not available
+        // Freighter watcher becomes available only after the extension exists.
       }
     })();
-  }, []);
+
+    return () => watcher?.stop();
+  }, [address, network, broadcast]);
 
   const connect = useCallback(async () => {
     const freighter = await import('@stellar/freighter-api');
     const { isConnected: connected } = await freighter.isConnected();
     if (!connected) {
+      setStatus('not_installed');
+      setStatusMessage('Install Freighter to connect a Stellar wallet.');
       throw new Error(
         'Freighter wallet not found. Please install the Freighter browser extension.',
       );
@@ -44,12 +234,37 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
     await freighter.requestAccess();
     const { address: addr } = await freighter.getAddress();
     if (!addr) throw new Error('Failed to get public key from Freighter');
+    const details = await freighter.getNetworkDetails();
+    const nextPreference = details.network ? networkToPreference(details.network) : null;
+    if (nextPreference) setPreferredNetwork(nextPreference);
+
     setAddress(addr);
-  }, []);
+    setNetwork(details.network || null);
+    setNetworkPassphrase(details.networkPassphrase || null);
+    setStatus('ready');
+    setStatusMessage('');
+    broadcast({
+      type: 'connected',
+      address: addr,
+      network: details.network || null,
+      networkPassphrase: details.networkPassphrase || null,
+    });
+  }, [broadcast, setPreferredNetwork]);
 
   const disconnect = useCallback(() => {
     setAddress(null);
-  }, []);
+    clearStellarStealthKeys();
+    broadcast({ type: 'disconnected' });
+  }, [broadcast]);
+
+  const retryInstallDetection = useCallback(() => {
+    let attempts = 0;
+    const interval = window.setInterval(async () => {
+      attempts++;
+      const restored = await restoreIfAllowed();
+      if (restored || attempts >= 15) window.clearInterval(interval);
+    }, 2000);
+  }, [restoreIfAllowed]);
 
   const signMessage = useCallback(
     async (message: string): Promise<Uint8Array> => {
@@ -58,23 +273,15 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
       const freighter = await import('@stellar/freighter-api');
       const { signedMessage } = await freighter.signMessage(message, {
         address,
-        networkPassphrase: STELLAR_NETWORK.networkPassphrase,
+        networkPassphrase: networkPassphrase ?? STELLAR_NETWORK.networkPassphrase,
       });
 
       if (!signedMessage) throw new Error('Signing failed: no signature returned');
 
-      // Freighter returns different types depending on version:
-      // - v3: Buffer (may arrive as serialized {type:'Buffer', data:[...]} through extension messaging)
-      // - v4: base64 string
-      // - could also be a raw Uint8Array/Buffer instance
       const msg = signedMessage as unknown;
-
-      if (msg instanceof Uint8Array) {
-        return msg;
-      }
+      if (msg instanceof Uint8Array) return msg;
 
       if (typeof msg === 'string') {
-        // base64 string
         const binaryString = atob(msg);
         const bytes = new Uint8Array(binaryString.length);
         for (let i = 0; i < binaryString.length; i++) {
@@ -83,7 +290,6 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
         return bytes;
       }
 
-      // Serialized Buffer: {type: 'Buffer', data: [1, 2, 3, ...]}
       if (
         msg &&
         typeof msg === 'object' &&
@@ -93,12 +299,11 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
         return new Uint8Array((msg as { data: number[] }).data);
       }
 
-      // Last resort: try to convert whatever it is
       throw new Error(
         `Unexpected signedMessage type: ${typeof msg} — ${JSON.stringify(msg).slice(0, 200)}`,
       );
     },
-    [address],
+    [address, networkPassphrase],
   );
 
   const signTransaction = useCallback(
@@ -108,17 +313,31 @@ export function StellarWalletProvider({ children }: { children: React.ReactNode 
       const freighter = await import('@stellar/freighter-api');
       const { signedTxXdr } = await freighter.signTransaction(xdr, {
         address,
-        networkPassphrase: STELLAR_NETWORK.networkPassphrase,
+        networkPassphrase: networkPassphrase ?? STELLAR_NETWORK.networkPassphrase,
       });
 
       return signedTxXdr;
     },
-    [address],
+    [address, networkPassphrase],
   );
 
   return (
     <StellarWalletContext.Provider
-      value={{ address, isConnected, connect, disconnect, signMessage, signTransaction }}
+      value={{
+        address,
+        isConnected,
+        status,
+        statusMessage,
+        network,
+        networkPassphrase,
+        preferredNetwork,
+        setPreferredNetwork,
+        connect,
+        disconnect,
+        retryInstallDetection,
+        signMessage,
+        signTransaction,
+      }}
     >
       {children}
     </StellarWalletContext.Provider>


### PR DESCRIPTION
## Summary
- restore allowed Freighter sessions on load without prompting again
- persist and synchronize the preferred Stellar network across tabs
- watch Freighter address/network changes and clear cached Stellar stealth keys when wallet state changes
- add install/approve CTA states with 30s retry polling after opening the Freighter install page

No wallet signatures or sensitive key material are cached; Stellar stealth keys are cleared on disconnect, address changes, and network changes.

Closes #4

## Validation
- npx prettier --check .
- npx tsc --noEmit
- git diff --check
- npx vite build
- npx pnpm@10 build

Build completed successfully. Vite still reports existing dependency/chunk-size warnings from bundled wallet SDK dependencies.