### PR TITLE
feat: add Stellar onboarding tour

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test:e2e": "playwright test",
     "preview": "vite preview",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",
+    "@playwright/test": "^1.60.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run build && npm run preview -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^19.0.0
         version: 19.8.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -731,6 +734,11 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rainbow-me/rainbowkit@2.2.10':
     resolution: {integrity: sha512-8+E4die1A2ovN9t3lWxWnwqTGEdFqThXDQRj+E4eDKuUKyymYD+66Gzm6S9yfg8E95c6hmGlavGUfYPtl1EagA==}
@@ -2593,6 +2601,11 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3386,6 +3399,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -5361,6 +5384,10 @@ snapshots:
       fastq: 1.20.1
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.47.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(wagmi@2.19.5(@react-native-async-storage/async-storage@1.24.0(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react-native@0.85.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(utf-8-validate@6.0.6))(react@19.2.5)(typescript@5.9.3)(utf-8-validate@6.0.6)(viem@2.47.17(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6))(zod@4.3.6))':
     dependencies:
@@ -8112,6 +8139,9 @@ snapshots:
 
   fresh@0.5.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -9011,6 +9041,14 @@ snapshots:
       thread-stream: 0.15.2
 
   pirates@4.0.7: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Header } from '@/components/Header';
 import { AutoSign } from '@/components/AutoSign';
+import { OnboardingTour, restartOnboardingTour } from '@/components/OnboardingTour';
+import copy from '@/i18n/en.json';
 import Send from '@/pages/Send';
 import Receive from '@/pages/Receive';
 
@@ -9,6 +11,7 @@ export function App() {
     <div className="flex min-h-screen flex-col">
       <Header />
       <AutoSign />
+      <OnboardingTour />
       <main className="mx-auto w-full max-w-[720px] flex-1 px-4 pb-16 pt-8 sm:px-6 sm:pb-24 sm:pt-10">
         <Routes>
           <Route path="/send" element={<Send />} />
@@ -16,6 +19,15 @@ export function App() {
           <Route path="*" element={<Navigate to="/send" replace />} />
         </Routes>
       </main>
+      <footer className="mx-auto flex w-full max-w-[720px] justify-end px-4 pb-6 sm:px-6">
+        <button
+          type="button"
+          onClick={restartOnboardingTour}
+          className="font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
+        >
+          {copy.onboarding.restart}
+        </button>
+      </footer>
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,7 @@ export function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
-    <header className="border-b border-outline-variant bg-surface">
+    <header data-tour="header" className="border-b border-outline-variant bg-surface">
       <div className="mx-auto flex max-w-[720px] items-center justify-between px-4 py-3 sm:px-6 sm:py-4">
         <div className="flex items-center gap-4">
           <Link to="/send" className="flex items-center gap-2">

--- a/src/components/OnboardingTour.tsx
+++ b/src/components/OnboardingTour.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import copy from '@/i18n/en.json';
+import { useChain } from '@/context/ChainContext';
+
+const STORAGE_KEY = 'wraith.tourCompleted';
+const EVENT_NAME = 'wraith:restart-tour';
+
+type TourStep = (typeof copy.onboarding.steps)[number];
+
+function interpolate(template: string, values: Record<string, number>) {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => String(values[key] ?? ''));
+}
+
+function isReducedMotion() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function restartOnboardingTour() {
+  localStorage.removeItem(STORAGE_KEY);
+  window.dispatchEvent(new Event(EVENT_NAME));
+}
+
+export function OnboardingTour() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { chain, setChain } = useChain();
+  const [active, setActive] = useState(false);
+  const [index, setIndex] = useState(0);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const steps = copy.onboarding.steps;
+  const currentStep: TourStep = steps[index];
+  const isLastStep = index === steps.length - 1;
+  const targetSelector = `[data-tour="${currentStep.target}"]`;
+
+  const start = useCallback(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    if (location.pathname !== '/send') navigate('/send');
+    if (chain !== 'stellar') setChain('stellar');
+    setIndex(0);
+    setActive(true);
+  }, [chain, location.pathname, navigate, setChain]);
+
+  const finish = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setActive(false);
+    previousFocusRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (localStorage.getItem(STORAGE_KEY)) return;
+    if (location.pathname === '/send' || location.pathname === '/') start();
+  }, [location.pathname, start]);
+
+  useEffect(() => {
+    const restart = () => start();
+    window.addEventListener(EVENT_NAME, restart);
+    return () => window.removeEventListener(EVENT_NAME, restart);
+  }, [start]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') finish();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [active, finish]);
+
+  useEffect(() => {
+    if (!active) return;
+    window.setTimeout(() => dialogRef.current?.querySelector<HTMLElement>('button')?.focus(), 0);
+  }, [active, index]);
+
+  useEffect(() => {
+    if (!active) return;
+    const target = document.querySelector<HTMLElement>(targetSelector);
+    target?.scrollIntoView({
+      block: 'center',
+      behavior: isReducedMotion() ? 'auto' : 'smooth',
+    });
+  }, [active, targetSelector]);
+
+  const next = () => {
+    if (isLastStep) {
+      finish();
+      return;
+    }
+    setIndex((nextIndex) => Math.min(nextIndex + 1, steps.length - 1));
+  };
+
+  if (!active) return null;
+
+  return (
+    <>
+      <div className="pointer-events-none fixed inset-0 z-40 bg-black/45" aria-hidden="true" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="wraith-tour-title"
+        aria-describedby="wraith-tour-body"
+        className="fixed bottom-4 left-4 right-4 z-50 border border-outline-variant bg-surface-container p-4 shadow-2xl sm:bottom-6 sm:left-auto sm:right-6 sm:w-[360px] sm:p-5"
+      >
+        <div className="flex flex-col gap-3">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+            {interpolate(copy.onboarding.stepCount, {
+              current: index + 1,
+              total: steps.length,
+            })}
+          </span>
+          <div className="flex flex-col gap-2">
+            <h2
+              id="wraith-tour-title"
+              className="font-heading text-sm font-bold uppercase tracking-widest text-on-surface"
+            >
+              {currentStep.title}
+            </h2>
+            <p
+              id="wraith-tour-body"
+              className="font-body text-sm leading-relaxed text-on-surface-variant"
+            >
+              {currentStep.body}
+            </p>
+          </div>
+          <div className="flex items-center justify-between gap-3 pt-2">
+            <button
+              type="button"
+              onClick={finish}
+              className="font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-on-surface"
+            >
+              {copy.onboarding.skip}
+            </button>
+            <button
+              type="button"
+              onClick={next}
+              className="h-9 border border-primary px-4 font-heading text-[10px] uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright"
+            >
+              {isLastStep ? copy.onboarding.done : copy.onboarding.next}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -194,7 +194,7 @@ export function StellarSend() {
 
   return (
     <section className="flex flex-col gap-8">
-      <div className="flex flex-col gap-2">
+      <div data-tour="send-page" className="flex flex-col gap-2">
         <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
           Stellar Testnet / XLM
         </span>
@@ -209,7 +209,7 @@ export function StellarSend() {
 
       {!stealthResult && (
         <div className="flex flex-col gap-6">
-          <div className="flex flex-col gap-1.5">
+          <div data-tour="recipient" className="flex flex-col gap-1.5">
             <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Recipient Meta-Address
             </label>
@@ -230,7 +230,7 @@ export function StellarSend() {
             </div>
           </div>
 
-          <div className="flex flex-col gap-1.5">
+          <div data-tour="amount" className="flex flex-col gap-1.5">
             <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Amount
             </label>
@@ -266,6 +266,7 @@ export function StellarSend() {
           {error && <p className="text-sm text-error">{error}</p>}
 
           <button
+            data-tour="submit"
             onClick={handleSend}
             disabled={!recipient || !amount || isPending}
             className="h-12 w-full bg-primary font-heading text-[13px] font-semibold uppercase tracking-widest text-surface transition-colors hover:brightness-110 disabled:opacity-30"

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -103,8 +103,12 @@ function CkbButton() {
 export function WalletConnect() {
   const { chain } = useChain();
 
-  if (chain === 'stellar') return <FreighterButton />;
-  if (chain === 'solana') return <SolanaButton />;
-  if (chain === 'ckb') return <CkbButton />;
-  return <HorizenButton />;
+  return (
+    <div data-tour="wallet">
+      {chain === 'stellar' && <FreighterButton />}
+      {chain === 'solana' && <SolanaButton />}
+      {chain === 'ckb' && <CkbButton />}
+      {chain === 'horizen' && <HorizenButton />}
+    </div>
+  );
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,36 @@
+{
+  "onboarding": {
+    "restart": "Take the tour",
+    "skip": "Skip",
+    "next": "Next",
+    "done": "Done",
+    "stepCount": "Step {{current}} of {{total}}",
+    "steps": [
+      {
+        "target": "header",
+        "title": "This is Wraith",
+        "body": "We're showing private payments on Stellar testnet. Click Connect Wallet to start."
+      },
+      {
+        "target": "wallet",
+        "title": "Wallet keys stay local",
+        "body": "We just asked your wallet to sign a stealth-key derivation message. These keys live in your browser, not on any server."
+      },
+      {
+        "target": "recipient",
+        "title": "Choose a private recipient",
+        "body": "Paste any Stellar stealth meta-address here, or type a .wraith name."
+      },
+      {
+        "target": "amount",
+        "title": "Set the XLM amount",
+        "body": "Enter an XLM amount. We'll generate a fresh stealth address, so the recipient's real address never appears on-chain."
+      },
+      {
+        "target": "submit",
+        "title": "Send privately",
+        "body": "When you send, the network sees a transfer to a new address that nobody can link to the recipient. Try it on testnet."
+      }
+    ]
+  }
+}

--- a/tests/e2e/onboarding-tour.spec.ts
+++ b/tests/e2e/onboarding-tour.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+test('first-time Stellar tour can be completed and restarted', async ({ page }) => {
+  await page.goto('/send');
+
+  const dialog = page.getByRole('dialog', { name: 'This is Wraith' });
+  await expect(dialog).toBeVisible();
+  await expect(page.getByText('Step 1 of 5')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('dialog', { name: 'Wallet keys stay local' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('dialog', { name: 'Choose a private recipient' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('dialog', { name: 'Set the XLM amount' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Next' }).click();
+  await expect(page.getByRole('dialog', { name: 'Send privately' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Done' }).click();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  await page.getByRole('button', { name: 'Take the tour' }).click();
+  await expect(page.getByRole('dialog', { name: 'This is Wraith' })).toBeVisible();
+});
+
+test('tour can be dismissed with Escape and stays dismissed after refresh', async ({ page }) => {
+  await page.goto('/send');
+
+  await expect(page.getByRole('dialog', { name: 'This is Wraith' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
## Summary
- add a first-run Stellar onboarding tour with five steps for the send flow
- persist dismissal in localStorage and add a footer restart entry point
- keep tour copy in `src/i18n/en.json` and anchor the tour to header, wallet, recipient, amount, and submit UI
- add Playwright e2e coverage for completion, restart, Escape dismissal, and refresh persistence

I used a small in-app tour controller instead of adding a tour dependency, keeping the shipped tour code minimal and avoiding another UI overlay package. The overlay does not trap clicks, supports Escape dismissal, restores focus after closing, and respects `prefers-reduced-motion` for scroll behavior.

Closes #17

## Validation
- npx prettier --check .
- npx tsc --noEmit
- git diff --check
- npx vite build
- npx playwright test

Build/test completed successfully. Vite still reports existing dependency/chunk-size warnings from bundled wallet SDK dependencies.