### PR TITLE
feat: add light theme parity and persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,19 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
+    <script>
+      (function () {
+        const THEME_KEY = 'wraith-theme';
+        const stored = localStorage.getItem(THEME_KEY);
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme =
+          stored === 'light' || stored === 'dark' ? stored : prefersDark ? 'dark' : 'light';
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+        document.documentElement.style.visibility = 'visible';
+      })();
+    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -18,8 +31,8 @@
     <link rel="manifest" href="/site.webmanifest" />
 
     <!-- Theme -->
-    <meta name="theme-color" content="#0e0e0e" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="color-scheme" content="light dark" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
@@ -49,7 +62,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-surface text-on-surface">
+  <body class="bg-surface text-on-surface" style="visibility: hidden">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  bufferutil: true
+  esbuild: true
+  keccak: true
+  utf-8-validate: true

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { ChainSwitcher } from './ChainSwitcher';
 import { WalletConnect } from './WalletConnect';
+import { useTheme } from '@/context/ThemeContext';
 
 const navLinks = [
   { to: '/send', label: 'Send' },
@@ -11,6 +12,7 @@ const navLinks = [
 export function Header() {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <header className="border-b border-outline-variant bg-surface">
@@ -44,6 +46,34 @@ export function Header() {
         </div>
 
         <div className="flex items-center gap-3">
+          <button
+            onClick={toggleTheme}
+            className="flex h-8 w-8 items-center justify-center text-outline transition-colors hover:text-on-surface-variant"
+            aria-label="Toggle theme"
+          >
+            {theme === 'light' ? (
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <path d="M8 1v2M8 13v2M3 8h2M11 8h2M4.5 4.5l1.4 1.4M10.1 10.1l1.4 1.4M4.5 11.5l1.4-1.4M10.1 5.9l1.4-1.4M8 5a3 3 0 1 0 0 6 3 3 0 0 0 0-6z" />
+              </svg>
+            ) : (
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <path d="M12 9a4 4 0 1 1-8 0 4 4 0 0 1 8 0z" />
+                <path d="M10 2a6 6 0 0 0-6 6" />
+              </svg>
+            )}
+          </button>
           <ChainSwitcher />
           <WalletConnect />
           <button

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const THEME_STORAGE_KEY = 'wraith-theme';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') return stored;
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) return;
+
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
+  }, [theme, isMounted]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,21 +2,62 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  /* Light theme (default) */
+  --color-surface: #ffffff;
+  --color-surface-container: #f5f5f5;
+  --color-surface-bright: #fafafa;
+  --color-primary: #1a1a1a;
+  --color-on-surface: #1a1a1a;
+  --color-on-surface-variant: #4a4a4a;
+  --color-outline: #6b6b6b;
+  --color-outline-variant: #e0e0e0;
+  --color-error: #d32f2f;
+  --color-tertiary: #2e7d32;
+  --color-selection-bg: #1a1a1a;
+  --color-selection-text: #ffffff;
+  --color-placeholder: #6b6b6b;
+  --color-scrollbar-track: #ffffff;
+  --color-scrollbar-thumb: #c0c0c0;
+}
+
+.dark {
+  /* Dark theme */
+  --color-surface: #0e0e0e;
+  --color-surface-container: #141414;
+  --color-surface-bright: #1a1a1a;
+  --color-primary: #c6c6c7;
+  --color-on-surface: #e6e1e5;
+  --color-on-surface-variant: #c4c7c5;
+  --color-outline: #767575;
+  --color-outline-variant: #444444;
+  --color-error: #ee7d77;
+  --color-tertiary: #22c55e;
+  --color-selection-bg: #c6c6c7;
+  --color-selection-text: #0e0e0e;
+  --color-placeholder: #767575;
+  --color-scrollbar-track: #0e0e0e;
+  --color-scrollbar-thumb: #444444;
+}
+
 body {
-  background-color: #0e0e0e;
-  color: #e6e1e5;
+  background-color: var(--color-surface);
+  color: var(--color-on-surface);
   font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition:
+    background-color 200ms ease,
+    color 200ms ease;
 }
 
 ::selection {
-  background-color: #c6c6c7;
-  color: #0e0e0e;
+  background-color: var(--color-selection-bg);
+  color: var(--color-selection-text);
 }
 
 input::placeholder {
-  color: #767575;
+  color: var(--color-placeholder);
 }
 
 input:focus {
@@ -29,18 +70,18 @@ input:focus {
 }
 
 ::-webkit-scrollbar-track {
-  background: #0e0e0e;
+  background: var(--color-scrollbar-track);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #444444;
+  background: var(--color-scrollbar-thumb);
 }
 
 /* Solana Wallet Adapter overrides */
 .wallet-adapter-button {
   background-color: transparent !important;
-  border: 1px solid #444444 !important;
-  color: #c6c6c7 !important;
+  border: 1px solid var(--color-outline-variant) !important;
+  color: var(--color-primary) !important;
   font-family: 'Space Grotesk', sans-serif !important;
   font-size: 10px !important;
   text-transform: uppercase !important;
@@ -59,7 +100,7 @@ input:focus {
 }
 
 .wallet-adapter-button:hover {
-  background-color: #1a1a1a !important;
+  background-color: var(--color-surface-bright) !important;
 }
 
 .wallet-adapter-button-trigger {
@@ -67,28 +108,28 @@ input:focus {
 }
 
 .wallet-adapter-modal-wrapper {
-  background-color: #141414 !important;
-  border: 1px solid #444444 !important;
+  background-color: var(--color-surface-container) !important;
+  border: 1px solid var(--color-outline-variant) !important;
   border-radius: 0 !important;
-  color: #e6e1e5 !important;
+  color: var(--color-on-surface) !important;
 }
 
 .wallet-adapter-modal-title {
-  color: #e6e1e5 !important;
+  color: var(--color-on-surface) !important;
   font-family: 'Space Grotesk', sans-serif !important;
 }
 
 .wallet-adapter-modal-list li {
-  background-color: #0e0e0e !important;
+  background-color: var(--color-surface) !important;
   border-radius: 0 !important;
 }
 
 .wallet-adapter-modal-list li:hover {
-  background-color: #1a1a1a !important;
+  background-color: var(--color-surface-bright) !important;
 }
 
 .wallet-adapter-modal-list .wallet-adapter-button {
-  color: #e6e1e5 !important;
+  color: var(--color-on-surface) !important;
   border: none !important;
   height: auto !important;
   padding: 8px 12px !important;
@@ -99,11 +140,11 @@ input:focus {
 
 .wallet-adapter-modal-button-close {
   background-color: transparent !important;
-  color: #767575 !important;
+  color: var(--color-outline) !important;
 }
 
 .wallet-adapter-modal-overlay {
-  background-color: rgba(0, 0, 0, 0.7) !important;
+  background-color: rgba(0, 0, 0, 0.5) !important;
 }
 
 /* CCC Connector overrides - target the ccc-connector web component */
@@ -118,8 +159,8 @@ ccc-connector [class*='modal'],
 ccc-connector [class*='container'],
 ccc-connector [class*='content'],
 ccc-connector [class*='body'] {
-  background-color: #141414 !important;
-  color: #e6e1e5 !important;
+  background-color: var(--color-surface-container) !important;
+  color: var(--color-on-surface) !important;
 }
 
 ccc-connector [class*='wallet'],
@@ -127,15 +168,15 @@ ccc-connector [class*='item'],
 ccc-connector [class*='option'],
 ccc-connector button[class*='wallet'],
 ccc-connector div[class*='wallet'] {
-  background-color: #0e0e0e !important;
-  color: #e6e1e5 !important;
+  background-color: var(--color-surface) !important;
+  color: var(--color-on-surface) !important;
   border-radius: 0 !important;
 }
 
 ccc-connector [class*='wallet']:hover,
 ccc-connector [class*='item']:hover,
 ccc-connector [class*='option']:hover {
-  background-color: #1a1a1a !important;
+  background-color: var(--color-surface-bright) !important;
 }
 
 ccc-connector span,
@@ -145,7 +186,7 @@ ccc-connector h2,
 ccc-connector h3,
 ccc-connector label,
 ccc-connector div {
-  color: #e6e1e5 !important;
+  color: var(--color-on-surface) !important;
 }
 
 ccc-connector button {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import { StrictMode, useState, useMemo, type CSSProperties } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { WagmiProvider } from 'wagmi';
-import { RainbowKitProvider, darkTheme } from '@rainbow-me/rainbowkit';
+import { RainbowKitProvider, darkTheme, lightTheme } from '@rainbow-me/rainbowkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   ConnectionProvider,
@@ -18,6 +18,7 @@ import { ccc } from '@ckb-ccc/connector-react';
 import { ChainProvider } from '@/context/ChainContext';
 import { StealthKeysProvider } from '@/context/StealthKeysContext';
 import { StellarWalletProvider } from '@/context/StellarWalletContext';
+import { ThemeProvider, useTheme } from '@/context/ThemeContext';
 import { wagmiConfig } from '@/config';
 import { App } from './App';
 import '@rainbow-me/rainbowkit/styles.css';
@@ -29,48 +30,54 @@ function Providers({ children }: { children: React.ReactNode }) {
   const solanaEndpoint = useMemo(() => clusterApiUrl('devnet'), []);
   const solanaWallets = useMemo(() => [new PhantomWalletAdapter()], []);
   const ckbClient = useMemo(() => new ccc.ClientPublicTestnet(), []);
+  const { theme } = useTheme();
+
+  const rainbowKitTheme = useMemo(() => {
+    const baseTheme = theme === 'dark' ? darkTheme : lightTheme;
+    return baseTheme({
+      accentColor: theme === 'dark' ? '#c6c6c7' : '#1a1a1a',
+      accentColorForeground: theme === 'dark' ? '#0e0e0e' : '#ffffff',
+      borderRadius: 'none',
+      fontStack: 'system',
+    });
+  }, [theme]);
 
   return (
-    <WagmiProvider config={wagmiConfig}>
-      <QueryClientProvider client={queryClient}>
-        <RainbowKitProvider
-          theme={darkTheme({
-            accentColor: '#c6c6c7',
-            accentColorForeground: '#0e0e0e',
-            borderRadius: 'none',
-            fontStack: 'system',
-          })}
-        >
-          <ConnectionProvider endpoint={solanaEndpoint}>
-            <SolanaWalletProvider wallets={solanaWallets} autoConnect>
-              <WalletModalProvider>
-                <ccc.Provider
-                  defaultClient={ckbClient}
-                  connectorProps={{
-                    style: {
-                      '--background': '#141414',
-                      '--divider': '#444444',
-                      '--btn-primary': '#c6c6c7',
-                      '--btn-primary-hover': '#e6e1e5',
-                      '--btn-secondary': '#0e0e0e',
-                      '--wallet-selected': '#1a1a1a',
-                      color: '#e6e1e5',
-                      borderRadius: '0px',
-                    } as CSSProperties,
-                  }}
-                >
-                  <ChainProvider>
-                    <StellarWalletProvider>
-                      <StealthKeysProvider>{children}</StealthKeysProvider>
-                    </StellarWalletProvider>
-                  </ChainProvider>
-                </ccc.Provider>
-              </WalletModalProvider>
-            </SolanaWalletProvider>
-          </ConnectionProvider>
-        </RainbowKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <ThemeProvider>
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={queryClient}>
+          <RainbowKitProvider theme={rainbowKitTheme}>
+            <ConnectionProvider endpoint={solanaEndpoint}>
+              <SolanaWalletProvider wallets={solanaWallets} autoConnect>
+                <WalletModalProvider>
+                  <ccc.Provider
+                    defaultClient={ckbClient}
+                    connectorProps={{
+                      style: {
+                        '--background': theme === 'dark' ? '#141414' : '#f5f5f5',
+                        '--divider': theme === 'dark' ? '#444444' : '#e0e0e0',
+                        '--btn-primary': theme === 'dark' ? '#c6c6c7' : '#1a1a1a',
+                        '--btn-primary-hover': theme === 'dark' ? '#e6e1e5' : '#4a4a4a',
+                        '--btn-secondary': theme === 'dark' ? '#0e0e0e' : '#ffffff',
+                        '--wallet-selected': theme === 'dark' ? '#1a1a1a' : '#fafafa',
+                        color: theme === 'dark' ? '#e6e1e5' : '#1a1a1a',
+                        borderRadius: '0px',
+                      } as CSSProperties,
+                    }}
+                  >
+                    <ChainProvider>
+                      <StellarWalletProvider>
+                        <StealthKeysProvider>{children}</StealthKeysProvider>
+                      </StellarWalletProvider>
+                    </ChainProvider>
+                  </ccc.Provider>
+                </WalletModalProvider>
+              </SolanaWalletProvider>
+            </ConnectionProvider>
+          </RainbowKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>
+    </ThemeProvider>
   );
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,19 +7,19 @@ const config: Config = {
     extend: {
       colors: {
         surface: {
-          DEFAULT: '#0e0e0e',
-          container: '#141414',
-          bright: '#1a1a1a',
+          DEFAULT: 'var(--color-surface)',
+          container: 'var(--color-surface-container)',
+          bright: 'var(--color-surface-bright)',
         },
-        primary: '#c6c6c7',
-        'on-surface': '#e6e1e5',
-        'on-surface-variant': '#c4c7c5',
+        primary: 'var(--color-primary)',
+        'on-surface': 'var(--color-on-surface)',
+        'on-surface-variant': 'var(--color-on-surface-variant)',
         outline: {
-          DEFAULT: '#767575',
-          variant: '#444444',
+          DEFAULT: 'var(--color-outline)',
+          variant: 'var(--color-outline-variant)',
         },
-        error: '#ee7d77',
-        tertiary: '#22c55e',
+        error: 'var(--color-error)',
+        tertiary: 'var(--color-tertiary)',
       },
       fontFamily: {
         heading: ['"Space Grotesk"', 'sans-serif'],


### PR DESCRIPTION
feat: add light theme parity and persistence

- Implement CSS variable design tokens
- Add theme toggle in header
- Persist theme preference in localStorage
- Default to prefers-color-scheme
- Add smooth theme transitions
- Prevent first-paint flash
- Support light/dark RainbowKit themes
- Ensure WCAG AA contrast compliance

Closes #71 