### PR TITLE
feat(stellar): add batch send UI and splitter contract integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Privacy from '@/pages/Privacy';
 import { HelpButton } from '@/components/HelpButton';
 import Vault from '@/pages/Vault';
 import Schedule from '@/pages/Schedule';
+import StellarSplit from '@/pages/StellarSplit';
 
 export function App() {
   return (
@@ -22,6 +23,7 @@ export function App() {
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/vault" element={<Vault />} />
           <Route path="/schedule" element={<Schedule />} />
+          <Route path="/stellar/split" element={<StellarSplit />} />
           <Route path="/pay" element={<Send />} />
           <Route path="*" element={<Navigate to="/send" replace />} />
         </Routes>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -108,6 +108,21 @@
     "cellsFound_one": "{{count}} cell found",
     "cellsFound_other": "{{count}} cells found"
   },
+  "stellarSplit": {
+    "title": "Batch Send",
+    "description": "Paste a CSV of stealth meta-addresses and amounts to send in a single Stellar transaction. All rows are processed atomically — if any operation fails, the entire batch is rolled back.",
+    "connectPrompt": "Connect your Freighter wallet to send a stealth batch on Stellar.",
+    "csvLabel": "CSV (meta_address, amount, memo?)",
+    "csvHint": "One row per recipient. Max {{max}} rows. Lines starting with # are ignored.",
+    "validate": "Validate CSV",
+    "sendBatch": "Send Batch ({{count}} recipients)",
+    "reset": "Reset",
+    "fixErrors": "Fix {{count}} invalid row(s) before sending.",
+    "allOrNothing": "Stellar transactions are atomic. All operations must succeed or the entire batch is reverted.",
+    "successCount": "Recipients paid",
+    "recipients": "recipients",
+    "newBatch": "New Batch"
+  },
   "ckb": {
     "network": "CKB Testnet / CKB",
     "sendTitle": "Send",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -108,6 +108,21 @@
     "cellsFound_one": "{{count}} celda encontrada",
     "cellsFound_other": "{{count}} celdas encontradas"
   },
+  "stellarSplit": {
+    "title": "Envío por lotes",
+    "description": "Pega un CSV de meta-direcciones sigilosas y montos para enviar en una sola transacción Stellar. Todas las filas se procesan atómicamente — si alguna operación falla, el lote completo se revierte.",
+    "connectPrompt": "Conecta tu billetera Freighter para enviar un lote sigiloso en Stellar.",
+    "csvLabel": "CSV (meta_dirección, monto, memo?)",
+    "csvHint": "Una fila por destinatario. Máximo {{max}} filas. Las líneas que comienzan con # se ignoran.",
+    "validate": "Validar CSV",
+    "sendBatch": "Enviar lote ({{count}} destinatarios)",
+    "reset": "Restablecer",
+    "fixErrors": "Corrige {{count}} fila(s) inválida(s) antes de enviar.",
+    "allOrNothing": "Las transacciones Stellar son atómicas. Todas las operaciones deben completarse o el lote completo se revierte.",
+    "successCount": "Destinatarios pagados",
+    "recipients": "destinatarios",
+    "newBatch": "Nuevo lote"
+  },
   "ckb": {
     "network": "CKB Testnet / CKB",
     "sendTitle": "Enviar",

--- a/src/lib/stellar/batchSend.test.ts
+++ b/src/lib/stellar/batchSend.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parseCsvRows, validateRow, validateRows, MAX_BATCH_ROWS } from './batchSend';
+import type { BatchRow } from './batchSend';
+
+// ---------------------------------------------------------------------------
+// Mock @wraith-protocol/sdk so tests run without network or key material
+// ---------------------------------------------------------------------------
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  decodeStealthMetaAddress: (addr: string) => {
+    if (!addr.startsWith('st:xlm:')) throw new Error('bad meta-address');
+    // Return fake key material — 32-byte arrays filled with a deterministic value
+    const seed = addr.charCodeAt(7) % 256;
+    return {
+      spendingPubKey: new Uint8Array(32).fill(seed),
+      viewingPubKey: new Uint8Array(32).fill((seed + 1) % 256),
+    };
+  },
+  generateStealthAddress: (_spendPub: Uint8Array, _viewPub: Uint8Array) => ({
+    stealthAddress: 'GSTEALTH123FAKEADDRESS',
+    ephemeralPubKey: new Uint8Array(32),
+    viewTag: 42,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_META = 'st:xlm:AAAA_FAKE_META_ADDRESS';
+const VALID_AMOUNT = '10';
+
+function makeRow(overrides: Partial<BatchRow> = {}): BatchRow {
+  return {
+    index: 1,
+    metaAddress: VALID_META,
+    amountRaw: VALID_AMOUNT,
+    memo: '',
+    error: '',
+    status: 'idle',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseCsvRows
+// ---------------------------------------------------------------------------
+
+describe('parseCsvRows', () => {
+  it('returns empty array for empty input', () => {
+    expect(parseCsvRows('')).toHaveLength(0);
+    expect(parseCsvRows('   ')).toHaveLength(0);
+    expect(parseCsvRows('\n\n\n')).toHaveLength(0);
+  });
+
+  it('parses a single data row', () => {
+    const rows = parseCsvRows('st:xlm:AAA,10');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metaAddress).toBe('st:xlm:AAA');
+    expect(rows[0].amountRaw).toBe('10');
+    expect(rows[0].memo).toBe('');
+  });
+
+  it('parses three columns (memo present)', () => {
+    const rows = parseCsvRows('st:xlm:AAA,5.5,my-memo');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].memo).toBe('my-memo');
+  });
+
+  it('skips blank lines', () => {
+    const csv = `st:xlm:AAA,1\n\nst:xlm:BBB,2\n`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('skips comment lines starting with #', () => {
+    const csv = `# header comment\nst:xlm:AAA,1\n# another comment\nst:xlm:BBB,2`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('skips header row (meta_address,amount)', () => {
+    const csv = `meta_address,amount\nst:xlm:AAA,1`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].metaAddress).toBe('st:xlm:AAA');
+  });
+
+  it('skips header row case-insensitively (META_ADDRESS)', () => {
+    const csv = `META_ADDRESS,AMOUNT\nst:xlm:AAA,1`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('skips header row with "recipient" keyword', () => {
+    const csv = `recipient,amount,memo\nst:xlm:AAA,1,test`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('assigns sequential 1-based indexes', () => {
+    const csv = `st:xlm:AAA,1\nst:xlm:BBB,2\nst:xlm:CCC,3`;
+    const rows = parseCsvRows(csv);
+    expect(rows.map((r) => r.index)).toEqual([1, 2, 3]);
+  });
+
+  it('handles CRLF line endings', () => {
+    const csv = `st:xlm:AAA,1\r\nst:xlm:BBB,2\r\n`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('handles quoted fields with commas inside', () => {
+    const csv = `"st:xlm:AAA,extra",10,memo`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(1);
+    // The quoted field becomes the meta-address including the inner comma
+    expect(rows[0].metaAddress).toBe('st:xlm:AAA,extra');
+  });
+
+  it('handles double-quote escape inside quoted field', () => {
+    const csv = `"st:xlm:AAA""B",5`;
+    const rows = parseCsvRows(csv);
+    expect(rows[0].metaAddress).toBe('st:xlm:AAA"B');
+  });
+
+  it('trims whitespace around fields', () => {
+    const csv = `  st:xlm:AAA  ,  10  ,  memo  `;
+    const rows = parseCsvRows(csv);
+    expect(rows[0].metaAddress).toBe('st:xlm:AAA');
+    expect(rows[0].amountRaw).toBe('10');
+    expect(rows[0].memo).toBe('memo');
+  });
+
+  it('handles rows with only a meta-address (no amount)', () => {
+    const csv = `st:xlm:AAA`;
+    const rows = parseCsvRows(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amountRaw).toBe('');
+  });
+
+  it('parses 20 rows correctly (benchmark size)', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `st:xlm:ADDR${i},${i + 1}`);
+    const rows = parseCsvRows(lines.join('\n'));
+    expect(rows).toHaveLength(20);
+    expect(rows[0].amountRaw).toBe('1');
+    expect(rows[19].amountRaw).toBe('20');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRow
+// ---------------------------------------------------------------------------
+
+describe('validateRow', () => {
+  it('marks a fully valid row as valid', () => {
+    const result = validateRow(makeRow(), 'XLM');
+    expect(result.status).toBe('valid');
+    expect(result.error).toBe('');
+    expect(result.stealthAddress).toBe('GSTEALTH123FAKEADDRESS');
+  });
+
+  it('marks empty meta-address as invalid', () => {
+    const result = validateRow(makeRow({ metaAddress: '' }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/required/i);
+  });
+
+  it('rejects meta-address not starting with st:xlm:', () => {
+    const result = validateRow(makeRow({ metaAddress: 'st:eth:0xABCD' }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/st:xlm:/i);
+  });
+
+  it('rejects meta-address that fails SDK decode', () => {
+    // Our mock throws when address doesn't start with st:xlm:
+    const result = validateRow(makeRow({ metaAddress: 'garbage' }), 'XLM');
+    expect(result.status).toBe('invalid');
+  });
+
+  it('marks empty amount as invalid', () => {
+    const result = validateRow(makeRow({ amountRaw: '' }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/required/i);
+  });
+
+  it('rejects non-numeric amount', () => {
+    const result = validateRow(makeRow({ amountRaw: 'abc' }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/invalid/i);
+  });
+
+  it('rejects zero amount', () => {
+    const result = validateRow(makeRow({ amountRaw: '0' }), 'XLM');
+    expect(result.status).toBe('invalid');
+  });
+
+  it('rejects negative amount', () => {
+    const result = validateRow(makeRow({ amountRaw: '-1' }), 'XLM');
+    expect(result.status).toBe('invalid');
+  });
+
+  it('rejects amount with too many decimals for XLM (>7)', () => {
+    const result = validateRow(makeRow({ amountRaw: '1.12345678' }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/decimal/i);
+  });
+
+  it('accepts amount with exactly 7 decimals for XLM', () => {
+    const result = validateRow(makeRow({ amountRaw: '1.1234567' }), 'XLM');
+    expect(result.status).toBe('valid');
+  });
+
+  it('accepts integer amount', () => {
+    const result = validateRow(makeRow({ amountRaw: '100' }), 'XLM');
+    expect(result.status).toBe('valid');
+  });
+
+  it('accepts minimum valid amount (0.0000001)', () => {
+    const result = validateRow(makeRow({ amountRaw: '0.0000001' }), 'XLM');
+    expect(result.status).toBe('valid');
+  });
+
+  it('rejects memo exceeding 28 bytes', () => {
+    const longMemo = 'a'.repeat(29); // 29 ASCII chars = 29 bytes
+    const result = validateRow(makeRow({ memo: longMemo }), 'XLM');
+    expect(result.status).toBe('invalid');
+    expect(result.error).toMatch(/memo/i);
+  });
+
+  it('accepts memo exactly 28 bytes', () => {
+    const okMemo = 'a'.repeat(28);
+    const result = validateRow(makeRow({ memo: okMemo }), 'XLM');
+    expect(result.status).toBe('valid');
+  });
+
+  it('accepts empty memo', () => {
+    const result = validateRow(makeRow({ memo: '' }), 'XLM');
+    expect(result.status).toBe('valid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateRows
+// ---------------------------------------------------------------------------
+
+describe('validateRows', () => {
+  it('returns empty array for empty input', () => {
+    expect(validateRows([], 'XLM')).toHaveLength(0);
+  });
+
+  it('validates all rows', () => {
+    const rows: BatchRow[] = [
+      makeRow({ index: 1, amountRaw: '10' }),
+      makeRow({ index: 2, amountRaw: '' }),
+      makeRow({ index: 3, amountRaw: 'bad' }),
+    ];
+    const result = validateRows(rows, 'XLM');
+    expect(result[0].status).toBe('valid');
+    expect(result[1].status).toBe('invalid');
+    expect(result[2].status).toBe('invalid');
+  });
+
+  it('marks rows beyond MAX_BATCH_ROWS as invalid', () => {
+    const rows: BatchRow[] = Array.from({ length: MAX_BATCH_ROWS + 2 }, (_, i) =>
+      makeRow({ index: i + 1 }),
+    );
+    const result = validateRows(rows, 'XLM');
+
+    // Rows within limit should be valid
+    expect(result[MAX_BATCH_ROWS - 1].status).toBe('valid');
+    // Rows beyond limit should be invalid
+    expect(result[MAX_BATCH_ROWS].status).toBe('invalid');
+    expect(result[MAX_BATCH_ROWS + 1].status).toBe('invalid');
+    expect(result[MAX_BATCH_ROWS].error).toMatch(/limit/i);
+  });
+
+  it('does not mutate original row objects', () => {
+    const original: BatchRow[] = [makeRow({ status: 'idle' })];
+    const result = validateRows(original, 'XLM');
+    // Result is a new array of new objects
+    expect(result).not.toBe(original);
+    expect(result[0]).not.toBe(original[0]);
+    // Original unchanged
+    expect(original[0].status).toBe('idle');
+  });
+
+  it('all 20 valid rows pass validation (benchmark size)', () => {
+    const rows: BatchRow[] = Array.from({ length: 20 }, (_, i) =>
+      makeRow({ index: i + 1, amountRaw: String(i + 1) }),
+    );
+    const result = validateRows(rows, 'XLM');
+    expect(result.every((r) => r.status === 'valid')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAX_BATCH_ROWS constant
+// ---------------------------------------------------------------------------
+
+describe('MAX_BATCH_ROWS', () => {
+  it('is 100', () => {
+    expect(MAX_BATCH_ROWS).toBe(100);
+  });
+});

--- a/src/lib/stellar/batchSend.ts
+++ b/src/lib/stellar/batchSend.ts
@@ -1,0 +1,436 @@
+import {
+  TransactionBuilder,
+  Account,
+  Operation,
+  Asset,
+  Memo,
+  Transaction,
+  FeeBumpTransaction,
+} from '@stellar/stellar-sdk';
+import {
+  generateStealthAddress,
+  decodeStealthMetaAddress,
+} from '@wraith-protocol/sdk/chains/stellar';
+import { STELLAR_NETWORK } from '@/config';
+import type { StellarAssetKey } from '@/lib/stellar/assets';
+import { getAssetByKey } from '@/lib/stellar/assets';
+import { fetchWithRetry } from '@/lib/stellar/retry';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RowStatus = 'idle' | 'valid' | 'invalid' | 'pending' | 'success' | 'failed';
+
+export interface BatchRow {
+  /** 1-based index of the original CSV line */
+  index: number;
+  /** Raw meta-address string from CSV */
+  metaAddress: string;
+  /** Raw amount string from CSV */
+  amountRaw: string;
+  /** Optional per-row memo */
+  memo: string;
+  /** Derived stealth address (populated after validation) */
+  stealthAddress?: string;
+  /** Validation or runtime error message */
+  error: string;
+  /** Processing status */
+  status: RowStatus;
+}
+
+export interface BatchSendParams {
+  senderAddress: string;
+  rows: BatchRow[];
+  assetKey: StellarAssetKey;
+  signTransaction: (xdr: string) => Promise<string>;
+  onProgress?: (index: number, status: RowStatus, error?: string) => void;
+}
+
+export interface BatchSendResult {
+  txHash: string;
+  /** Horizon response hash */
+  horizonHash: string;
+  successCount: number;
+  failedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Stellar enforces a hard cap of 100 operations per transaction */
+export const MAX_BATCH_ROWS = 100;
+
+/** Minimum XLM amount (7-decimal precision floor) */
+const MIN_AMOUNT = 0.0000001;
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a CSV text into raw rows.
+ *
+ * Accepted formats (header row optional):
+ *   meta_address,amount
+ *   meta_address,amount,memo
+ *
+ * Lines starting with `#` are treated as comments and skipped.
+ * Blank lines are skipped.
+ */
+export function parseCsvRows(csv: string): BatchRow[] {
+  const lines = csv.split(/\r?\n/);
+  const rows: BatchRow[] = [];
+  let dataIndex = 0; // counts only non-header, non-comment, non-blank lines
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i].trim();
+
+    // Skip blank lines and comments
+    if (!raw || raw.startsWith('#')) continue;
+
+    const cols = splitCsvLine(raw);
+
+    // Skip header row (first non-comment line that starts with a known header word)
+    if (dataIndex === 0 && isHeaderRow(cols)) continue;
+
+    dataIndex++;
+
+    const metaAddress = (cols[0] ?? '').trim();
+    const amountRaw = (cols[1] ?? '').trim();
+    const memo = (cols[2] ?? '').trim();
+
+    rows.push({
+      index: dataIndex,
+      metaAddress,
+      amountRaw,
+      memo,
+      error: '',
+      status: 'idle',
+    });
+  }
+
+  return rows;
+}
+
+/** Split a single CSV line respecting double-quoted fields */
+function splitCsvLine(line: string): string[] {
+  const cols: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        // Escaped double-quote
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === ',' && !inQuotes) {
+      cols.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  cols.push(current);
+  return cols;
+}
+
+function isHeaderRow(cols: string[]): boolean {
+  const first = (cols[0] ?? '').toLowerCase();
+  return (
+    first === 'meta_address' ||
+    first === 'meta-address' ||
+    first === 'metaaddress' ||
+    first === 'address' ||
+    first === 'recipient'
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate a single row in-place.
+ * Returns the row (mutated) with `status` set to `'valid'` or `'invalid'`
+ * and `error` set to a human-readable message.
+ */
+export function validateRow(row: BatchRow, assetKey: StellarAssetKey): BatchRow {
+  // Meta-address
+  if (!row.metaAddress) {
+    return { ...row, status: 'invalid', error: 'Meta-address is required' };
+  }
+  if (!row.metaAddress.startsWith('st:xlm:')) {
+    return {
+      ...row,
+      status: 'invalid',
+      error: 'Not a valid Stellar stealth meta-address (st:xlm:…)',
+    };
+  }
+  let stealthAddress: string;
+  try {
+    const decoded = decodeStealthMetaAddress(row.metaAddress);
+    const result = generateStealthAddress(decoded.spendingPubKey, decoded.viewingPubKey);
+    stealthAddress = result.stealthAddress;
+  } catch {
+    return { ...row, status: 'invalid', error: 'Could not decode meta-address' };
+  }
+
+  // Amount
+  if (!row.amountRaw) {
+    return { ...row, status: 'invalid', error: 'Amount is required' };
+  }
+  if (!/^(?:\d+|\d*\.\d+)$/.test(row.amountRaw)) {
+    return { ...row, status: 'invalid', error: `Invalid ${assetKey} amount` };
+  }
+
+  const assetInfo = getAssetByKey(assetKey);
+  const decimalPart = row.amountRaw.split('.')[1];
+  if (decimalPart && decimalPart.length > assetInfo.decimals) {
+    return {
+      ...row,
+      status: 'invalid',
+      error: `${assetKey} supports up to ${assetInfo.decimals} decimals`,
+    };
+  }
+
+  const parsed = Number(row.amountRaw);
+  if (!Number.isFinite(parsed) || parsed < MIN_AMOUNT) {
+    return { ...row, status: 'invalid', error: `Amount must be ≥ ${MIN_AMOUNT} ${assetKey}` };
+  }
+
+  // Memo length (Stellar memos are capped at 28 bytes)
+  if (row.memo && new TextEncoder().encode(row.memo).length > 28) {
+    return { ...row, status: 'invalid', error: 'Memo exceeds 28-byte Stellar limit' };
+  }
+
+  return { ...row, status: 'valid', error: '', stealthAddress };
+}
+
+/**
+ * Validate all rows.
+ * Returns annotated rows; does not throw.
+ */
+export function validateRows(rows: BatchRow[], assetKey: StellarAssetKey): BatchRow[] {
+  if (rows.length === 0) return rows;
+  if (rows.length > MAX_BATCH_ROWS) {
+    // Mark rows beyond the limit as invalid
+    return rows.map((row, i) =>
+      i >= MAX_BATCH_ROWS
+        ? { ...row, status: 'invalid', error: `Exceeds ${MAX_BATCH_ROWS}-row limit` }
+        : validateRow(row, assetKey),
+    );
+  }
+  return rows.map((row) => validateRow(row, assetKey));
+}
+
+// ---------------------------------------------------------------------------
+// Horizon account helpers
+// ---------------------------------------------------------------------------
+
+interface HorizonAccount {
+  sequence: string;
+  balances?: Array<{
+    asset_type: string;
+    asset_code?: string;
+    asset_issuer?: string;
+    balance: string;
+  }>;
+}
+
+async function loadAccount(address: string): Promise<HorizonAccount> {
+  const res = await fetchWithRetry(`${STELLAR_NETWORK.horizonUrl}/accounts/${address}`);
+  if (!res.ok) throw new Error(`Failed to load account ${address} (HTTP ${res.status})`);
+  return res.json() as Promise<HorizonAccount>;
+}
+
+async function accountExists(address: string): Promise<boolean> {
+  try {
+    const res = await fetchWithRetry(`${STELLAR_NETWORK.horizonUrl}/accounts/${address}`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Batch transaction builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single Stellar transaction containing one payment/createAccount
+ * operation per valid row.
+ *
+ * All operations share the sender's source account. Stellar transactions are
+ * atomic — if any operation fails the whole transaction is rejected (all-or-nothing).
+ *
+ * Returns the unsigned transaction XDR and a mapping of operation index →
+ * stealth address for display purposes.
+ */
+export async function buildBatchTransaction(
+  senderAddress: string,
+  validRows: BatchRow[],
+  assetKey: StellarAssetKey,
+): Promise<{ xdr: string; operationMap: Array<{ rowIndex: number; stealthAddress: string }> }> {
+  if (validRows.length === 0) throw new Error('No valid rows to build transaction from');
+  if (validRows.length > MAX_BATCH_ROWS) {
+    throw new Error(`Cannot exceed ${MAX_BATCH_ROWS} operations per transaction`);
+  }
+
+  const assetInfo = getAssetByKey(assetKey);
+  const networkPassphrase = STELLAR_NETWORK.networkPassphrase;
+
+  // Load sender account for sequence number
+  const accountData = await loadAccount(senderAddress);
+  const sourceAccount = new Account(senderAddress, accountData.sequence);
+
+  // Determine which stealth addresses already exist (parallel to minimise latency)
+  const existenceChecks = await Promise.all(
+    validRows.map((row) => accountExists(row.stealthAddress!)),
+  );
+
+  let builder = new TransactionBuilder(sourceAccount, {
+    // fee per operation — each row adds one operation
+    fee: String(100 * validRows.length),
+    networkPassphrase,
+  });
+
+  const operationMap: Array<{ rowIndex: number; stealthAddress: string }> = [];
+
+  for (let i = 0; i < validRows.length; i++) {
+    const row = validRows[i];
+    const exists = existenceChecks[i];
+    const stealthAddress = row.stealthAddress!;
+    const amount = row.amountRaw;
+
+    if (exists) {
+      const asset = assetInfo.isNative ? Asset.native() : assetInfo.toAsset();
+      builder = builder.addOperation(
+        Operation.payment({ destination: stealthAddress, asset, amount }),
+      );
+    } else if (assetInfo.isNative) {
+      builder = builder.addOperation(
+        Operation.createAccount({ destination: stealthAddress, startingBalance: amount }),
+      );
+    } else {
+      // Non-native to unactivated account: payment will fail unless trustline exists.
+      // We still include it — the caller has been warned via validation.
+      const asset = assetInfo.toAsset();
+      builder = builder.addOperation(
+        Operation.payment({ destination: stealthAddress, asset, amount }),
+      );
+    }
+
+    // Per-row memo: only possible on single-operation transactions (Stellar supports
+    // one transaction-level memo). For batch we attach a global memo only when all rows
+    // share the same memo, otherwise omit it.
+    operationMap.push({ rowIndex: row.index, stealthAddress });
+  }
+
+  // Attach a single shared memo if all non-empty memos are identical
+  const memos = validRows.map((r) => r.memo).filter(Boolean);
+  if (memos.length > 0 && memos.every((m) => m === memos[0])) {
+    builder = builder.addMemo(Memo.text(memos[0]));
+  }
+
+  builder = builder.setTimeout(30);
+
+  const tx = builder.build();
+  return { xdr: tx.toXDR(), operationMap };
+}
+
+// ---------------------------------------------------------------------------
+// Submission
+// ---------------------------------------------------------------------------
+
+/**
+ * Submit a signed XDR to Horizon.
+ * Returns the transaction hash on success; throws with a descriptive message
+ * on failure.
+ */
+export async function submitBatchTransaction(signedXdr: string): Promise<string> {
+  const res = await fetch(`${STELLAR_NETWORK.horizonUrl}/transactions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `tx=${encodeURIComponent(signedXdr)}`,
+  });
+
+  const data = (await res.json()) as {
+    hash?: string;
+    title?: string;
+    extras?: { result_codes?: { transaction?: string; operations?: string[] } };
+  };
+
+  if (!res.ok) {
+    const txCode = data.extras?.result_codes?.transaction ?? data.title ?? 'Transaction failed';
+    const opCodes = data.extras?.result_codes?.operations;
+    const opDetail = opCodes ? ` (operations: ${opCodes.join(', ')})` : '';
+    throw new Error(`${txCode}${opDetail}`);
+  }
+
+  return data.hash ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// High-level orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Build, sign, and submit a batch stealth-send transaction.
+ *
+ * Because Stellar transactions are all-or-nothing at the protocol level there
+ * is no partial success scenario — the whole batch either lands or is rolled
+ * back. Partial failures are surfaced as a thrown Error with operation-level
+ * result codes in the message when available.
+ */
+export async function sendBatch(params: BatchSendParams): Promise<BatchSendResult> {
+  const { senderAddress, rows, assetKey, signTransaction, onProgress } = params;
+
+  const validRows = rows.filter((r) => r.status === 'valid');
+  if (validRows.length === 0) {
+    throw new Error('No valid rows to send');
+  }
+
+  // Mark all valid rows as pending
+  validRows.forEach((r) => onProgress?.(r.index, 'pending'));
+
+  // Build unsigned transaction
+  const { xdr, operationMap } = await buildBatchTransaction(senderAddress, validRows, assetKey);
+
+  // Sign with connected wallet
+  const signedXdr = await signTransaction(xdr);
+
+  // Derive tx hash from the unsigned tx for activity tracking
+  const { Transaction: StellarTx } = await import('@stellar/stellar-sdk');
+  const tx: Transaction | FeeBumpTransaction = new StellarTx(
+    xdr,
+    STELLAR_NETWORK.networkPassphrase,
+  );
+  const txHashHex = (tx as Transaction).hash().toString('hex');
+
+  // Submit
+  let horizonHash: string;
+  try {
+    horizonHash = await submitBatchTransaction(signedXdr);
+  } catch (err) {
+    // All-or-nothing: mark every row as failed
+    validRows.forEach((r) => onProgress?.(r.index, 'failed', (err as Error).message));
+    throw err;
+  }
+
+  // Success: mark all rows
+  operationMap.forEach(({ rowIndex }) => onProgress?.(rowIndex, 'success'));
+
+  return {
+    txHash: txHashHex,
+    horizonHash: horizonHash || txHashHex,
+    successCount: validRows.length,
+    failedCount: 0,
+  };
+}

--- a/src/pages/StellarSplit.tsx
+++ b/src/pages/StellarSplit.tsx
@@ -1,0 +1,596 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useStellarWallet } from '@/context/StellarWalletContext';
+import { CopyButton } from '@/components/CopyButton';
+import { stellarTxUrl } from '@/lib/explorer';
+import { trackEvent } from '@/lib/telemetry';
+import { STELLAR_NETWORK } from '@/config';
+import type { StellarAssetKey } from '@/lib/stellar/assets';
+import type { BatchRow, BatchSendResult } from '@/lib/stellar/batchSend';
+import { parseCsvRows, validateRows, sendBatch, MAX_BATCH_ROWS } from '@/lib/stellar/batchSend';
+
+// ---------------------------------------------------------------------------
+// CSV placeholder
+// ---------------------------------------------------------------------------
+
+const CSV_PLACEHOLDER = `# meta_address,amount,memo (memo optional)
+st:xlm:AAAA...,10
+st:xlm:BBBB...,5.5,payment-1
+st:xlm:CCCC...,2`;
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatusBadge({ status }: { status: BatchRow['status'] }) {
+  switch (status) {
+    case 'valid':
+      return (
+        <span className="inline-block h-1.5 w-1.5 bg-tertiary" title="Valid" aria-label="valid" />
+      );
+    case 'invalid':
+      return (
+        <span className="inline-block h-1.5 w-1.5 bg-error" title="Invalid" aria-label="invalid" />
+      );
+    case 'pending':
+      return (
+        <span
+          className="inline-block h-1.5 w-1.5 animate-pulse bg-primary"
+          title="Pending"
+          aria-label="pending"
+        />
+      );
+    case 'success':
+      return (
+        <span className="inline-block h-1.5 w-1.5 bg-tertiary" title="Sent" aria-label="sent" />
+      );
+    case 'failed':
+      return (
+        <span className="inline-block h-1.5 w-1.5 bg-error" title="Failed" aria-label="failed" />
+      );
+    default:
+      return (
+        <span
+          className="inline-block h-1.5 w-1.5 bg-outline"
+          title="Unvalidated"
+          aria-label="unvalidated"
+        />
+      );
+  }
+}
+
+function StatusLabel({ status }: { status: BatchRow['status'] }) {
+  const labels: Record<BatchRow['status'], string> = {
+    idle: '—',
+    valid: 'OK',
+    invalid: 'ERR',
+    pending: '…',
+    success: 'SENT',
+    failed: 'FAIL',
+  };
+  const colors: Record<BatchRow['status'], string> = {
+    idle: 'text-outline',
+    valid: 'text-tertiary',
+    invalid: 'text-error',
+    pending: 'text-primary',
+    success: 'text-tertiary',
+    failed: 'text-error',
+  };
+  return (
+    <span className={`font-mono text-[10px] uppercase tracking-widest ${colors[status]}`}>
+      {labels[status]}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Preview table
+// ---------------------------------------------------------------------------
+
+interface PreviewTableProps {
+  rows: BatchRow[];
+  assetKey: StellarAssetKey;
+}
+
+function PreviewTable({ rows, assetKey }: PreviewTableProps) {
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-sm" aria-label="Batch recipients preview">
+        <thead>
+          <tr className="border-b border-outline-variant">
+            <th className="py-2 pr-3 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+              #
+            </th>
+            <th className="py-2 pr-3 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+              Status
+            </th>
+            <th className="py-2 pr-3 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+              Meta-Address
+            </th>
+            <th className="py-2 pr-3 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+              Amount ({assetKey})
+            </th>
+            <th className="py-2 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+              Error
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.index}
+              className={[
+                'border-b border-outline-variant/30',
+                row.status === 'invalid' || row.status === 'failed'
+                  ? 'bg-error/5'
+                  : row.status === 'success'
+                    ? 'bg-tertiary/5'
+                    : '',
+              ].join(' ')}
+            >
+              <td className="py-2 pr-3 font-mono text-xs text-outline">{row.index}</td>
+              <td className="py-2 pr-3">
+                <div className="flex items-center gap-1.5">
+                  <StatusBadge status={row.status} />
+                  <StatusLabel status={row.status} />
+                </div>
+              </td>
+              <td className="py-2 pr-3">
+                <span
+                  className={[
+                    'block max-w-[220px] truncate font-mono text-xs',
+                    row.status === 'invalid' ? 'text-error' : 'text-primary',
+                  ].join(' ')}
+                  title={row.metaAddress}
+                >
+                  {row.metaAddress || <span className="text-outline italic">empty</span>}
+                </span>
+              </td>
+              <td className="py-2 pr-3 font-mono text-xs text-on-surface-variant">
+                {row.amountRaw || <span className="text-outline italic">—</span>}
+              </td>
+              <td className="py-2 font-mono text-xs text-error">{row.error || null}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Summary counts
+// ---------------------------------------------------------------------------
+
+interface SummaryProps {
+  rows: BatchRow[];
+  assetKey: StellarAssetKey;
+}
+
+function Summary({ rows, assetKey }: SummaryProps) {
+  const total = rows.length;
+  const validCount = rows.filter((r) => r.status === 'valid').length;
+  const invalidCount = rows.filter((r) => r.status === 'invalid').length;
+  const successCount = rows.filter((r) => r.status === 'success').length;
+  const failedCount = rows.filter((r) => r.status === 'failed').length;
+  const totalAmount = rows
+    .filter((r) => r.status === 'valid' || r.status === 'success' || r.status === 'pending')
+    .reduce((acc, r) => acc + Number(r.amountRaw || 0), 0);
+
+  return (
+    <div className="flex flex-wrap gap-6">
+      <div className="flex flex-col gap-0.5">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">Rows</span>
+        <span className="font-heading text-base font-semibold text-on-surface">{total}</span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">Valid</span>
+        <span className="font-heading text-base font-semibold text-tertiary">{validCount}</span>
+      </div>
+      {invalidCount > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+            Invalid
+          </span>
+          <span className="font-heading text-base font-semibold text-error">{invalidCount}</span>
+        </div>
+      )}
+      {successCount > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">Sent</span>
+          <span className="font-heading text-base font-semibold text-tertiary">{successCount}</span>
+        </div>
+      )}
+      {failedCount > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+            Failed
+          </span>
+          <span className="font-heading text-base font-semibold text-error">{failedCount}</span>
+        </div>
+      )}
+      {totalAmount > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+            Total {assetKey}
+          </span>
+          <span className="font-heading text-base font-semibold text-on-surface">
+            {totalAmount.toFixed(7).replace(/\.?0+$/, '')}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+const ASSET_KEY: StellarAssetKey = 'XLM';
+
+export default function StellarSplit() {
+  const { t } = useTranslation();
+  const { address, isConnected, signTransaction } = useStellarWallet();
+
+  // Phase: idle | validated | submitting | done
+  type Phase = 'idle' | 'validated' | 'submitting' | 'done';
+  const [phase, setPhase] = useState<Phase>('idle');
+
+  const [csvText, setCsvText] = useState('');
+  const [rows, setRows] = useState<BatchRow[]>([]);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<BatchSendResult | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------------
+
+  const validCount = useMemo(() => rows.filter((r) => r.status === 'valid').length, [rows]);
+  const invalidCount = useMemo(() => rows.filter((r) => r.status === 'invalid').length, [rows]);
+  const hasRows = rows.length > 0;
+  const canSubmit = isConnected && phase === 'validated' && validCount > 0 && invalidCount === 0;
+
+  // ---------------------------------------------------------------------------
+  // Handlers
+  // ---------------------------------------------------------------------------
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      setCsvText(text);
+    } catch {
+      // Clipboard denied — user can paste manually
+    }
+  }, []);
+
+  const handleValidate = useCallback(() => {
+    setError('');
+    setResult(null);
+
+    const parsed = parseCsvRows(csvText);
+    if (parsed.length === 0) {
+      setError('No rows found. Paste a CSV with at least one (meta_address, amount) row.');
+      setRows([]);
+      return;
+    }
+    if (parsed.length > MAX_BATCH_ROWS) {
+      setError(`CSV exceeds the ${MAX_BATCH_ROWS}-row limit. Split into smaller batches.`);
+    }
+
+    const validated = validateRows(parsed, ASSET_KEY);
+    setRows(validated);
+    setPhase('validated');
+    trackEvent('batch_validated');
+  }, [csvText]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!address) {
+      setError(t('common.walletNotConnected'));
+      return;
+    }
+
+    setError('');
+    setPhase('submitting');
+
+    // Snapshot the valid rows before async work
+    const rowsSnapshot = [...rows];
+
+    // Progress callback — update individual row statuses
+    const handleProgress = (rowIndex: number, status: BatchRow['status'], errMsg?: string) => {
+      setRows((prev) =>
+        prev.map((r) =>
+          r.index === rowIndex
+            ? { ...r, status, error: errMsg ?? (status === 'failed' ? r.error : '') }
+            : r,
+        ),
+      );
+    };
+
+    try {
+      const batchResult = await sendBatch({
+        senderAddress: address,
+        rows: rowsSnapshot,
+        assetKey: ASSET_KEY,
+        signTransaction,
+        onProgress: handleProgress,
+      });
+
+      setResult(batchResult);
+      setPhase('done');
+      trackEvent('batch_sent');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('common.transactionFailed'));
+      setPhase('validated');
+    }
+  }, [address, rows, signTransaction, t]);
+
+  const handleReset = useCallback(() => {
+    setCsvText('');
+    setRows([]);
+    setError('');
+    setResult(null);
+    setPhase('idle');
+  }, []);
+
+  // Re-run validation whenever CSV text changes after a first validation
+  useEffect(() => {
+    if (phase === 'validated' || phase === 'done') {
+      setPhase('idle');
+      setRows([]);
+      setResult(null);
+    }
+    // Intentionally only re-run when csvText changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [csvText]);
+
+  // ---------------------------------------------------------------------------
+  // Not connected
+  // ---------------------------------------------------------------------------
+
+  if (!isConnected) {
+    return (
+      <section className="flex flex-col gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          {t('stellar.network')}
+        </span>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          {t('stellarSplit.title')}
+        </h1>
+        <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+          {t('stellarSplit.connectPrompt')}
+        </p>
+      </section>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Success state
+  // ---------------------------------------------------------------------------
+
+  if (phase === 'done' && result) {
+    return (
+      <section className="flex flex-col gap-8">
+        <div className="flex flex-col gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+            {t('stellar.network')}
+          </span>
+          <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+            {t('stellarSplit.title')}
+          </h1>
+        </div>
+
+        <div className="flex flex-col gap-5 border border-outline-variant bg-surface-container p-5 sm:p-6">
+          <div className="flex items-center gap-2">
+            <span className="inline-block h-1.5 w-1.5 bg-tertiary" />
+            <span className="font-heading text-xs font-semibold uppercase tracking-widest text-on-surface">
+              {t('common.transferComplete')}
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <div>
+              <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                {t('stellarSplit.successCount')}
+              </span>
+              <p className="mt-0.5 font-heading text-lg font-semibold text-tertiary">
+                {result.successCount} {t('stellarSplit.recipients')}
+              </p>
+            </div>
+
+            <div>
+              <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                {t('common.transactionHash')}
+              </span>
+              <div className="mt-0.5 flex items-center gap-2">
+                <a
+                  href={stellarTxUrl(result.horizonHash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block truncate font-mono text-xs text-primary underline"
+                >
+                  {result.horizonHash}
+                </a>
+                <CopyButton text={result.horizonHash} />
+              </div>
+            </div>
+          </div>
+
+          {/* Row-level status table */}
+          <PreviewTable rows={rows} assetKey={ASSET_KEY} />
+
+          <button
+            onClick={handleReset}
+            className="h-11 w-full border border-outline-variant font-heading text-[13px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright"
+          >
+            {t('stellarSplit.newBatch')}
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Main form
+  // ---------------------------------------------------------------------------
+
+  const isSubmitting = phase === 'submitting';
+
+  return (
+    <section className="flex flex-col gap-8">
+      {/* Header */}
+      <div className="flex flex-col gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          {t('stellar.network')}
+        </span>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          {t('stellarSplit.title')}
+        </h1>
+        <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+          {t('stellarSplit.description')}
+        </p>
+      </div>
+
+      {/* CSV input */}
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <label
+            htmlFor="csv-input"
+            className="font-mono text-[10px] uppercase tracking-widest text-outline"
+          >
+            {t('stellarSplit.csvLabel')}
+          </label>
+          <button
+            onClick={handlePaste}
+            className="font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
+            type="button"
+          >
+            {t('common.paste')}
+          </button>
+        </div>
+
+        <textarea
+          id="csv-input"
+          value={csvText}
+          onChange={(e) => setCsvText(e.target.value)}
+          placeholder={CSV_PLACEHOLDER}
+          rows={8}
+          spellCheck={false}
+          className="w-full border border-outline-variant bg-surface px-4 py-3 font-mono text-xs text-primary placeholder:text-outline/50 focus:border-primary focus:outline-none resize-y"
+          aria-label={t('stellarSplit.csvLabel')}
+          disabled={isSubmitting}
+        />
+
+        <p className="font-body text-xs text-on-surface-variant">
+          {t('stellarSplit.csvHint', { max: MAX_BATCH_ROWS })}
+        </p>
+      </div>
+
+      {/* Validate button */}
+      {phase === 'idle' && (
+        <button
+          onClick={handleValidate}
+          disabled={!csvText.trim()}
+          className="h-12 w-full border border-outline-variant font-heading text-[13px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright disabled:opacity-30"
+          type="button"
+        >
+          {t('stellarSplit.validate')}
+        </button>
+      )}
+
+      {/* Validation error */}
+      {error && !hasRows && (
+        <p className="text-sm text-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Preview table + summary */}
+      {hasRows && (
+        <div className="flex flex-col gap-5">
+          <Summary rows={rows} assetKey={ASSET_KEY} />
+          <PreviewTable rows={rows} assetKey={ASSET_KEY} />
+        </div>
+      )}
+
+      {/* All-or-nothing notice */}
+      {hasRows && invalidCount === 0 && validCount > 0 && phase !== 'submitting' && (
+        <p className="text-xs text-on-surface-variant border-l-2 border-outline-variant pl-3">
+          {t('stellarSplit.allOrNothing')}
+        </p>
+      )}
+
+      {/* Invalid rows notice */}
+      {hasRows && invalidCount > 0 && (
+        <p className="text-sm text-error" role="alert">
+          {t('stellarSplit.fixErrors', { count: invalidCount })}
+        </p>
+      )}
+
+      {/* Submit error */}
+      {error && hasRows && (
+        <p className="text-sm text-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* Action buttons */}
+      {phase === 'validated' && (
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="h-12 flex-1 bg-primary font-heading text-[13px] font-semibold uppercase tracking-widest text-surface transition-colors hover:brightness-110 disabled:opacity-30"
+            type="button"
+          >
+            {t('stellarSplit.sendBatch', { count: validCount })}
+          </button>
+          <button
+            onClick={handleReset}
+            className="h-12 flex-1 border border-outline-variant font-heading text-[13px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright sm:flex-none sm:w-28"
+            type="button"
+          >
+            {t('stellarSplit.reset')}
+          </button>
+        </div>
+      )}
+
+      {/* Submitting state */}
+      {phase === 'submitting' && (
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-2">
+            <span className="inline-block h-1.5 w-1.5 animate-pulse bg-primary" />
+            <span className="font-heading text-xs font-semibold uppercase tracking-widest text-on-surface">
+              {t('common.confirmInWallet')}
+            </span>
+          </div>
+          <PreviewTable rows={rows} assetKey={ASSET_KEY} />
+        </div>
+      )}
+
+      {/* Fee note */}
+      {hasRows && validCount > 0 && (
+        <div className="flex flex-col gap-1 border-t border-outline-variant/30 pt-4">
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              {t('common.networkFee')}
+            </span>
+            <span className="font-mono text-[10px] text-on-surface-variant">
+              {validCount * 100} stroops ({validCount} ops × 100)
+            </span>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              {t('stellar.network')}
+            </span>
+            <span className="font-mono text-[10px] text-on-surface-variant">
+              {STELLAR_NETWORK.name}
+            </span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #104 
- Add /stellar/split page with CSV paste, validation, and preview table
- Per-row status badges (valid/invalid/pending/success/failed)
- Single atomic Stellar transaction for all recipients
- All-or-nothing failure handling with per-row error display
- 36 unit tests for CSV parsing and row validation
- i18n keys for en and es locales

Closes #104