### PR TITLE
feat: add unknown recipient warning for stealth payments

### DIFF
--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -18,6 +18,9 @@ import {
 } from '@wraith-protocol/sdk/chains/stellar';
 import { useTranslation } from 'react-i18next';
 import { useStellarWallet } from '@/context/StellarWalletContext';
+import { useContacts } from '@/store/contactsStore';
+import { useNameHistory } from '@/store/nameHistoryStore';
+import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
 import { STELLAR_NETWORK } from '@/config';
 import { CopyButton } from '@/components/CopyButton';
 import { trackEvent } from '@/lib/telemetry';
@@ -104,6 +107,8 @@ export function StellarSend() {
   const [amount, setAmount] = useState(paramAmount || '');
   const [assetKey] = useState<StellarAssetKey>('XLM');
   const [memo, setMemo] = useState(paramMemo || '');
+  const { isKnownAddress, addContact } = useContacts();
+  const { isKnownRecipient, addToHistory } = useNameHistory();
   const [error, setError] = useState('');
   const [, setTouched] = useState({ recipient: false, amount: false });
   const [, setSubmitAttempted] = useState(false);
@@ -183,6 +188,9 @@ export function StellarSend() {
     }
   }, [paramExp]);
 
+  const [showUnknownWarning, setShowUnknownWarning] = useState(false);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [contactName, setContactName] = useState('');
   const [stealthResult, setStealthResult] = useState<{
     stealthAddress: string;
     ephemeralPubKey: Uint8Array;
@@ -382,6 +390,10 @@ export function StellarSend() {
     };
   }, [metaAddress, assetKey, recipientError]);
 
+  // Check if recipient is known when it changes
+  const isUnknownRecipient =
+    recipient && !isKnownAddress(recipient) && !isKnownRecipient(recipient);
+
   const handleSend = useCallback(async () => {
     setSubmitAttempted(true);
     setTouched({ recipient: true, amount: true });
@@ -508,6 +520,9 @@ export function StellarSend() {
 
       setTxHash(submitData.hash);
 
+      // Add recipient to history after successful send
+      addToHistory(recipient);
+
       // Announce via Soroban (best-effort)
       try {
         const { rpc: rpcMod } = await import('@stellar/stellar-sdk');
@@ -585,6 +600,17 @@ export function StellarSend() {
     setSubmitAttempted(false);
     setSourceBalance(null);
     setBalanceLookupError('');
+    setShowUnknownWarning(false);
+    setShowSaveDialog(false);
+    setContactName('');
+  };
+
+  const handleSaveContact = () => {
+    if (contactName.trim() && recipient) {
+      addContact(recipient, contactName.trim());
+      setShowSaveDialog(false);
+      setContactName('');
+    }
   };
 
   const handlePaste = async () => {
@@ -688,6 +714,60 @@ export function StellarSend() {
           </div>
 
           {error && <p className="text-sm text-error">{error}</p>}
+
+          {isUnknownRecipient && (
+            <div className="flex flex-col gap-3 rounded border border-outline-variant/50 bg-surface-container p-4">
+              <div className="flex items-start gap-2">
+                <span className="text-lg">⚠️</span>
+                <div className="flex flex-col gap-1">
+                  <p className="text-sm font-medium text-on-surface">
+                    You haven't paid this recipient before
+                  </p>
+                  <p className="text-xs text-on-surface-variant">
+                    This address is not in your contacts or payment history. Please verify the
+                    address carefully before sending.
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => setShowSaveDialog(true)}
+                className="h-9 w-full border border-outline-variant font-heading text-[11px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright"
+              >
+                Save to contacts
+              </button>
+            </div>
+          )}
+
+          {showSaveDialog && (
+            <div className="flex flex-col gap-3 rounded border border-outline-variant bg-surface-container p-4">
+              <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                Contact Name
+              </label>
+              <input
+                type="text"
+                value={contactName}
+                onChange={(e) => setContactName(e.target.value)}
+                placeholder="Enter a name for this contact"
+                className="h-10 w-full border border-outline-variant bg-surface px-3 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
+                autoFocus
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setShowSaveDialog(false)}
+                  className="h-9 flex-1 border border-outline-variant font-heading text-[11px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSaveContact}
+                  disabled={!contactName.trim()}
+                  className="h-9 flex-1 bg-primary font-heading text-[11px] font-semibold uppercase tracking-widest text-surface transition-colors hover:brightness-110 disabled:opacity-30"
+                >
+                  Save
+                </button>
+              </div>
+            </div>
+          )}
 
           <button
             onClick={handleSend}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -33,6 +33,8 @@ import { ChainProvider } from '@/context/ChainContext';
 import { StealthKeysProvider } from '@/context/StealthKeysContext';
 import { StellarWalletProvider } from '@/context/StellarWalletContext';
 import { ThemeProvider, useTheme } from '@/context/ThemeContext';
+import { ContactsProvider } from '@/store/contactsStore';
+import { NameHistoryProvider } from '@/store/nameHistoryStore';
 import { wagmiConfig } from '@/config';
 import { App } from './App';
 import '@rainbow-me/rainbowkit/styles.css';
@@ -81,7 +83,11 @@ function Providers({ children }: { children: React.ReactNode }) {
                   >
                     <ChainProvider>
                       <StellarWalletProvider>
-                        <StealthKeysProvider>{children}</StealthKeysProvider>
+                        <ContactsProvider>
+                          <NameHistoryProvider>
+                            <StealthKeysProvider>{children}</StealthKeysProvider>
+                          </NameHistoryProvider>
+                        </ContactsProvider>
                       </StellarWalletProvider>
                     </ChainProvider>
                   </ccc.Provider>
@@ -94,7 +100,6 @@ function Providers({ children }: { children: React.ReactNode }) {
     </ThemeProvider>
   );
 }
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>

--- a/src/store/contactsStore.tsx
+++ b/src/store/contactsStore.tsx
@@ -1,0 +1,74 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+interface Contact {
+  address: string;
+  name: string;
+  addedAt: number;
+}
+
+interface ContactsContextValue {
+  contacts: Contact[];
+  addContact: (address: string, name: string) => void;
+  removeContact: (address: string) => void;
+  isKnownAddress: (address: string) => boolean;
+  getContactName: (address: string) => string | undefined;
+}
+
+const ContactsContext = createContext<ContactsContextValue | null>(null);
+
+const STORAGE_KEY = 'wraith-contacts';
+
+export function ContactsProvider({ children }: { children: ReactNode }) {
+  const [contacts, setContacts] = useState<Contact[]>([]);
+
+  // Load contacts from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setContacts(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  // Save contacts to localStorage when they change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(contacts));
+  }, [contacts]);
+
+  const addContact = (address: string, name: string) => {
+    setContacts((prev) => {
+      // Remove existing contact with same address if exists
+      const filtered = prev.filter((c) => c.address !== address);
+      return [...filtered, { address, name, addedAt: Date.now() }];
+    });
+  };
+
+  const removeContact = (address: string) => {
+    setContacts((prev) => prev.filter((c) => c.address !== address));
+  };
+
+  const isKnownAddress = (address: string) => {
+    return contacts.some((c) => c.address === address);
+  };
+
+  const getContactName = (address: string) => {
+    return contacts.find((c) => c.address === address)?.name;
+  };
+
+  return (
+    <ContactsContext.Provider
+      value={{ contacts, addContact, removeContact, isKnownAddress, getContactName }}
+    >
+      {children}
+    </ContactsContext.Provider>
+  );
+}
+
+export function useContacts() {
+  const ctx = useContext(ContactsContext);
+  if (!ctx) throw new Error('useContacts must be used within ContactsProvider');
+  return ctx;
+}

--- a/src/store/nameHistoryStore.tsx
+++ b/src/store/nameHistoryStore.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+
+interface NameHistoryEntry {
+  address: string;
+  name?: string;
+  lastUsed: number;
+}
+
+interface NameHistoryContextValue {
+  history: NameHistoryEntry[];
+  addToHistory: (address: string, name?: string) => void;
+  isKnownRecipient: (address: string) => boolean;
+}
+
+const NameHistoryContext = createContext<NameHistoryContextValue | null>(null);
+
+const STORAGE_KEY = 'wraith-name-history';
+
+export function NameHistoryProvider({ children }: { children: ReactNode }) {
+  const [history, setHistory] = useState<NameHistoryEntry[]>([]);
+
+  // Load history from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setHistory(JSON.parse(stored));
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }, []);
+
+  // Save history to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  }, [history]);
+
+  const addToHistory = (address: string, name?: string) => {
+    setHistory((prev) => {
+      // Remove existing entry with same address if exists
+      const filtered = prev.filter((h) => h.address !== address);
+      return [...filtered, { address, name, lastUsed: Date.now() }];
+    });
+  };
+
+  const isKnownRecipient = (address: string) => {
+    return history.some((h) => h.address === address);
+  };
+
+  return (
+    <NameHistoryContext.Provider value={{ history, addToHistory, isKnownRecipient }}>
+      {children}
+    </NameHistoryContext.Provider>
+  );
+}
+
+export function useNameHistory() {
+  const ctx = useContext(NameHistoryContext);
+  if (!ctx) throw new Error('useNameHistory must be used within NameHistoryProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Add unknown recipient warning for stealth payments

Closes #117

### Summary
Adds a soft warning when sending to a recipient that hasn't received a payment before, along with a lightweight way to save new recipients to a personal address book — without ever blocking the send flow.

### Changes

**New files:**
- `src/store/contactsStore.tsx` — address book management with localStorage persistence (add/remove contacts, look up by address, get contact name)
- `src/store/nameHistoryStore.tsx` — tracks recipients a user has previously sent payments to

**Modified files:**
- `src/main.tsx` — wraps the app in `ContactsProvider` and `NameHistoryProvider`
- `src/components/StellarSend.tsx` — recipient validation against contacts + history, warning UI, and save-to-contacts dialog

### Features
- Checks recipient address against both the address book and payment history
- Shows a soft warning — *"You haven't paid this recipient before"* — for unknown addresses
- Includes a "Save to contacts" action that opens an inline dialog to name and save the recipient
- Warning is informational only; it never blocks or delays sending
- Known recipients (in contacts or history) show no warning
- Recipients are automatically added to history after a successful transaction

### Testing
- `pnpm build` passes with zero TypeScript/build errors
- Manually verified: warning displays for new addresses, disappears for known ones, save-to-contacts dialog works end-to-end, and history updates after a successful send
- Confirmed no regression to existing payment-link pre-fill flow (`?to=`, `?amount=`, `?exp=` params) or theme switching, both of which share code paths modified in this PR