### PR TITLE
feat(stellar): add expert deep links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Schedule from '@/pages/Schedule';
 import StellarSplit from '@/pages/StellarSplit';
 import Names from '@/pages/Names';
 import Activity from '@/pages/Activity';
+import Debug from '@/pages/Debug';
 
 export function App() {
   return (
@@ -29,6 +30,8 @@ export function App() {
           <Route path="/pay" element={<Send />} />
           <Route path="/names" element={<Names />} />
           <Route path="/activity" element={<Activity />} />
+          <Route path="/history" element={<Activity />} />
+          <Route path="/debug" element={<Debug />} />
           <Route path="*" element={<Navigate to="/send" replace />} />
         </Routes>
       </main>

--- a/src/components/ActivityRow.tsx
+++ b/src/components/ActivityRow.tsx
@@ -1,11 +1,14 @@
 import { ActivityEntry } from '@/stores/activityStore';
 import { stellarTxUrl, horizenTxUrl, solanaTxUrl, ckbTxUrl } from '@/lib/explorer';
+import { StellarLink } from '@/components/StellarLink';
 
 interface ActivityRowProps {
   entry: ActivityEntry;
 }
 
 export function ActivityRow({ entry }: ActivityRowProps) {
+  const isStellarAccount =
+    entry.chain === 'stellar' && !!entry.recipient && /^[GM][A-Z2-7]+$/.test(entry.recipient);
   const getExplorerUrl = () => {
     switch (entry.chain) {
       case 'stellar':
@@ -115,14 +118,23 @@ export function ActivityRow({ entry }: ActivityRowProps) {
             <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Recipient / Address
             </span>
-            <span
-              className="max-w-[200px] truncate font-mono text-[10px] text-on-surface"
-              title={entry.recipient}
-            >
-              {entry.recipient.length > 30
-                ? `${entry.recipient.slice(0, 12)}...${entry.recipient.slice(-12)}`
-                : entry.recipient}
-            </span>
+            {isStellarAccount ? (
+              <StellarLink
+                value={entry.recipient!}
+                type="account"
+                className="max-w-[240px]"
+                linkClassName="text-[10px]"
+              />
+            ) : (
+              <span
+                className="max-w-[200px] truncate font-mono text-[10px] text-on-surface"
+                title={entry.recipient}
+              >
+                {entry.recipient.length > 30
+                  ? `${entry.recipient.slice(0, 12)}...${entry.recipient.slice(-12)}`
+                  : entry.recipient}
+              </span>
+            )}
           </div>
         )}
 
@@ -131,14 +143,18 @@ export function ActivityRow({ entry }: ActivityRowProps) {
             <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Hash
             </span>
-            <a
-              href={getExplorerUrl()}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-[10px] text-tertiary hover:underline"
-            >
-              {entry.id.slice(0, 12)}...{entry.id.slice(-12)}
-            </a>
+            {entry.chain === 'stellar' ? (
+              <StellarLink value={entry.id} type="tx" linkClassName="text-[10px]" />
+            ) : (
+              <a
+                href={getExplorerUrl()}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-[10px] text-tertiary hover:underline"
+              >
+                {entry.id.slice(0, 12)}...{entry.id.slice(-12)}
+              </a>
+            )}
           </div>
         )}
       </div>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -6,6 +6,8 @@ export function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   return (
     <button
+      type="button"
+      aria-label={`Copy ${text}`}
       onClick={() => {
         navigator.clipboard.writeText(text);
         setCopied(true);

--- a/src/components/FreighterConnectButton.tsx
+++ b/src/components/FreighterConnectButton.tsx
@@ -1,3 +1,5 @@
+import { StellarLink } from '@/components/StellarLink';
+
 export const walletBtnBase =
   'bg-transparent border border-outline-variant px-3 py-1.5 font-heading text-[10px] uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright disabled:opacity-50 sm:px-4 sm:py-2 sm:text-xs h-8 sm:h-9';
 export const walletBtnConnected =
@@ -47,9 +49,19 @@ export function FreighterConnectButton({
 
   if (status === 'connected' && address) {
     return (
-      <button onClick={onDisconnect} className={walletBtnConnected}>
-        {address.slice(0, 4)}...{address.slice(-4)}
-      </button>
+      <div className={`${walletBtnConnected} flex items-center gap-2`}>
+        <StellarLink value={address} type="account" linkClassName="text-[10px] sm:text-xs">
+          {address.slice(0, 4)}...{address.slice(-4)}
+        </StellarLink>
+        <button
+          type="button"
+          onClick={onDisconnect}
+          className="text-outline transition-colors hover:text-error"
+          aria-label="Disconnect Stellar wallet"
+        >
+          ×
+        </button>
+      </div>
     );
   }
 

--- a/src/components/StellarHistory.tsx
+++ b/src/components/StellarHistory.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useStellarWallet } from '@/context/StellarWalletContext';
-import { stellarTxUrl } from '@/lib/explorer';
 import { useActivityStore, ActivityKind, ActivityStatus } from '@/stores/activityStore';
 import { EmptyState } from '@/components/EmptyState';
+import { StellarLink } from '@/components/StellarLink';
 
+/** @deprecated Use the `/activity` page. Retained for existing imports. */
 export function StellarHistory() {
   const navigate = useNavigate();
   const { address, isConnected } = useStellarWallet();
@@ -186,14 +187,23 @@ export function StellarHistory() {
                   <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
                     Recipient / Address
                   </span>
-                  <span
-                    className="max-w-[200px] truncate font-mono text-[10px] text-on-surface"
-                    title={tx.recipient}
-                  >
-                    {tx.recipient.length > 30
-                      ? `${tx.recipient.slice(0, 12)}...${tx.recipient.slice(-12)}`
-                      : tx.recipient}
-                  </span>
+                  {/^[GM][A-Z2-7]+$/.test(tx.recipient) ? (
+                    <StellarLink
+                      value={tx.recipient}
+                      type="account"
+                      className="max-w-[240px]"
+                      linkClassName="text-[10px]"
+                    />
+                  ) : (
+                    <span
+                      className="max-w-[200px] truncate font-mono text-[10px] text-on-surface"
+                      title={tx.recipient}
+                    >
+                      {tx.recipient.length > 30
+                        ? `${tx.recipient.slice(0, 12)}...${tx.recipient.slice(-12)}`
+                        : tx.recipient}
+                    </span>
+                  )}
                 </div>
               )}
 
@@ -202,14 +212,7 @@ export function StellarHistory() {
                   <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
                     Hash
                   </span>
-                  <a
-                    href={stellarTxUrl(tx.id)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-mono text-[10px] text-tertiary hover:underline"
-                  >
-                    {tx.id.slice(0, 12)}...{tx.id.slice(-12)}
-                  </a>
+                  <StellarLink value={tx.id} type="tx" linkClassName="text-[10px]" />
                 </div>
               )}
             </div>

--- a/src/components/StellarLink.tsx
+++ b/src/components/StellarLink.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { CopyButton } from '@/components/CopyButton';
+import {
+  stellarExpertUrl,
+  type StellarExpertNetworkInput,
+  type StellarExpertResource,
+} from '@/utils/stellarExpert';
+
+interface StellarLinkProps {
+  value: string;
+  type: StellarExpertResource;
+  network?: StellarExpertNetworkInput;
+  children?: ReactNode;
+  className?: string;
+  linkClassName?: string;
+}
+
+function truncateIdentifier(value: string): string {
+  if (value.length <= 28) return value;
+  return `${value.slice(0, 12)}...${value.slice(-12)}`;
+}
+
+export function StellarLink({
+  value,
+  type,
+  network,
+  children,
+  className = '',
+  linkClassName = '',
+}: StellarLinkProps) {
+  const resourceLabel = type === 'tx' ? 'transaction' : type;
+
+  return (
+    <span className={`inline-flex min-w-0 items-center gap-2 ${className}`}>
+      <a
+        href={stellarExpertUrl(type, value, network)}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={value}
+        aria-label={`View Stellar ${resourceLabel} ${value} on Stellar Expert`}
+        className={`min-w-0 truncate font-mono text-tertiary underline decoration-outline underline-offset-2 transition-colors hover:text-primary ${linkClassName}`}
+      >
+        {children ?? truncateIdentifier(value)}
+      </a>
+      <CopyButton text={value} />
+    </span>
+  );
+}

--- a/src/components/StellarMatchCard.tsx
+++ b/src/components/StellarMatchCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
 import { CopyButton } from '@/components/CopyButton';
+import { StellarLink } from '@/components/StellarLink';
 import { PrivacyTooltip } from '@/components/PrivacyTooltip';
 import type { StellarAssetKey } from '@/lib/stellar/assets';
 import { STELLAR_ASSETS, getAssetByKey, formatStellarAssetAmount } from '@/lib/stellar/assets';
@@ -340,17 +340,12 @@ export function StellarMatchCard({
           <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
             Stealth Address
           </span>
-          <div className="mt-0.5 flex items-center gap-2">
-            <a
-              href={stellarAddrUrl(stealthAddress)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block truncate font-mono text-xs text-primary underline"
-            >
-              {stealthAddress}
-            </a>
-            <CopyButton text={stealthAddress} />
-          </div>
+          <StellarLink
+            value={stealthAddress}
+            type="account"
+            className="mt-0.5 max-w-full"
+            linkClassName="text-xs"
+          />
         </div>
         <div className="flex shrink-0 flex-col items-end gap-0.5">
           {balanceState === 'loading' ? (
@@ -454,14 +449,7 @@ export function StellarMatchCard({
             <span className="inline-block h-1.5 w-1.5 bg-tertiary"></span>
             <span className="font-mono text-[10px] text-on-surface-variant">
               {feeBumpHash ? 'Sponsored withdrawal complete' : 'Withdrawn'} —{' '}
-              <a
-                href={stellarTxUrl(withdrawHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                {withdrawHash.slice(0, 14)}...
-              </a>
+              <StellarLink value={withdrawHash} type="tx" linkClassName="text-[10px]" />
             </span>
           </div>
           {feeBumpHash && (

--- a/src/components/StellarReceive.tsx
+++ b/src/components/StellarReceive.tsx
@@ -28,7 +28,7 @@ import { useStellarWallet } from '@/context/StellarWalletContext';
 import { useActivity } from '@/context/ActivityContext';
 import { CopyButton } from '@/components/CopyButton';
 import { trackEvent } from '@/lib/telemetry';
-import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
+import { StellarLink } from '@/components/StellarLink';
 import { PrivacyBadge } from '@/components/PrivacyBadge';
 import { computePrivacyScore } from '@/lib/privacy-score';
 import { STELLAR_NETWORK } from '@/config';
@@ -531,15 +531,12 @@ function StellarMatchCardContainer({
               {t('common.stealthAddress')}
             </span>
             <div className="mt-0.5 flex items-center gap-2">
-              <a
-                href={stellarAddrUrl(match.stealthAddress)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block truncate font-mono text-xs text-primary underline"
-              >
-                {match.stealthAddress}
-              </a>
-              <CopyButton text={match.stealthAddress} />
+              <StellarLink
+                value={match.stealthAddress}
+                type="account"
+                className="max-w-full"
+                linkClassName="text-xs"
+              />
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
@@ -596,14 +593,7 @@ function StellarMatchCardContainer({
             <span className="inline-block h-1.5 w-1.5 bg-tertiary"></span>
             <span className="font-mono text-[10px] text-on-surface-variant">
               {t('common.withdrawn')} —{' '}
-              <a
-                href={stellarTxUrl(withdrawHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                {withdrawHash.slice(0, 14)}...
-              </a>
+              <StellarLink value={withdrawHash} type="tx" linkClassName="text-[10px]" />
             </span>
           </div>
         )}

--- a/src/components/StellarReceiveView.tsx
+++ b/src/components/StellarReceiveView.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { stellarTxUrl } from '@/lib/explorer';
+import { StellarLink } from '@/components/StellarLink';
 import { CopyButton } from '@/components/CopyButton';
 import { StellarPaymentLink } from '@/components/StellarPaymentLink';
 import { ImportConflictModal } from '@/components/ImportConflictModal';
@@ -191,14 +191,7 @@ export function StellarReceiveView({
                   {regHash && (
                     <>
                       {' — '}
-                      <a
-                        href={stellarTxUrl(regHash)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary underline"
-                      >
-                        {regHash.slice(0, 14)}...
-                      </a>
+                      <StellarLink value={regHash} type="tx" linkClassName="text-xs" />
                     </>
                   )}
                 </span>

--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -20,7 +20,6 @@ import { useTranslation } from 'react-i18next';
 import { useStellarWallet } from '@/context/StellarWalletContext';
 import { useContacts } from '@/store/contactsStore';
 import { useNameHistory } from '@/store/nameHistoryStore';
-import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
 import { STELLAR_NETWORK } from '@/config';
 import { CopyButton } from '@/components/CopyButton';
 import { AssetPicker } from '@/components/AssetPicker';
@@ -29,7 +28,7 @@ import type { StellarAssetKey } from '@/lib/stellar/assets';
 import { getAssetByKey, STELLAR_ASSETS } from '@/lib/stellar/assets';
 import { checkAssetTrustline } from '@/lib/stellar/buildSendStellarAsset';
 import { fetchWithRetry, withRetry, RetryExhaustedError } from '@/lib/stellar/retry';
-import { stellarAddrUrl, stellarTxUrl } from '@/lib/explorer';
+import { StellarLink } from '@/components/StellarLink';
 import {
   type StellarSendSimulationState,
   emptyStellarSendSimulation,
@@ -870,15 +869,12 @@ export function StellarSend() {
                 {t('common.stealthAddress')}
               </span>
               <div className="mt-0.5 flex items-center gap-2">
-                <a
-                  href={stellarAddrUrl(stealthResult.stealthAddress)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block truncate font-mono text-xs text-primary underline"
-                >
-                  {stealthResult.stealthAddress}
-                </a>
-                <CopyButton text={stealthResult.stealthAddress} />
+                <StellarLink
+                  value={stealthResult.stealthAddress}
+                  type="account"
+                  className="max-w-full"
+                  linkClassName="text-xs"
+                />
               </div>
             </div>
 
@@ -888,15 +884,12 @@ export function StellarSend() {
                   {t('common.transactionHash')}
                 </span>
                 <div className="mt-0.5 flex items-center gap-2">
-                  <a
-                    href={stellarTxUrl(txHash)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block truncate font-mono text-xs text-primary underline"
-                  >
-                    {txHash}
-                  </a>
-                  <CopyButton text={txHash} />
+                  <StellarLink
+                    value={txHash}
+                    type="tx"
+                    className="max-w-full"
+                    linkClassName="text-xs"
+                  />
                 </div>
               </div>
             )}

--- a/src/components/StellarSendView.tsx
+++ b/src/components/StellarSendView.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react';
-import { stellarTxUrl, stellarAddrUrl } from '@/lib/explorer';
-import { CopyButton } from '@/components/CopyButton';
+import { StellarLink } from '@/components/StellarLink';
 import type { StellarAssetKey } from '@/lib/stellar/assets';
 import { STELLAR_ASSETS } from '@/lib/stellar/assets';
 
@@ -394,15 +393,12 @@ export function StellarSendView({
                 Stealth Address
               </span>
               <div className="mt-0.5 flex min-w-0  items-center gap-2">
-                <a
-                  href={stellarAddrUrl(stealthResult.stealthAddress)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block truncate font-mono text-xs text-primary underline"
-                >
-                  {stealthResult.stealthAddress}
-                </a>
-                <CopyButton text={stealthResult.stealthAddress} />
+                <StellarLink
+                  value={stealthResult.stealthAddress}
+                  type="account"
+                  className="max-w-full"
+                  linkClassName="text-xs"
+                />
               </div>
             </div>
 
@@ -412,15 +408,12 @@ export function StellarSendView({
                   Final Transaction Hash
                 </span>
                 <div className="mt-0.5 flex min-w-0 items-center gap-2">
-                  <a
-                    href={stellarTxUrl(txHash)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block truncate font-mono text-xs text-primary underline"
-                  >
-                    {txHash}
-                  </a>
-                  <CopyButton text={txHash} />
+                  <StellarLink
+                    value={txHash}
+                    type="tx"
+                    className="max-w-full"
+                    linkClassName="text-xs"
+                  />
                 </div>
               </div>
             )}

--- a/src/components/StellarVaultClaim.tsx
+++ b/src/components/StellarVaultClaim.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
-import { useStellarWallet } from '@/context/StellarWalletContext';
-import { stellarTxUrl } from '@/lib/explorer';
 import { CopyButton } from '@/components/CopyButton';
+import { useStellarWallet } from '@/context/StellarWalletContext';
+import { StellarLink } from '@/components/StellarLink';
 
 type ClaimState = 'idle' | 'signing' | 'claiming' | 'success';
 
@@ -119,17 +119,12 @@ export function StellarVaultClaim() {
             <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Transaction Hash
             </span>
-            <div className="mt-0.5 flex items-center gap-2">
-              <a
-                href={stellarTxUrl(txHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-xs text-primary underline"
-              >
-                {txHash}
-              </a>
-              <CopyButton text={txHash} />
-            </div>
+            <StellarLink
+              value={txHash}
+              type="tx"
+              className="mt-0.5 max-w-full"
+              linkClassName="text-xs"
+            />
           </div>
         </div>
 

--- a/src/components/StellarVaultDeposit.tsx
+++ b/src/components/StellarVaultDeposit.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { decodeStealthMetaAddress } from '@wraith-protocol/sdk/chains/stellar';
 import { useStellarWallet } from '@/context/StellarWalletContext';
 import { CopyButton } from '@/components/CopyButton';
+import { StellarLink } from '@/components/StellarLink';
 
 const MIN_XLM_AMOUNT = 0.0000001;
 
@@ -289,10 +290,12 @@ export function StellarVaultDeposit() {
                 <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
                   Transaction Hash
                 </span>
-                <div className="mt-0.5 flex items-center gap-2">
-                  <span className="font-mono text-xs text-primary">{txHash}</span>
-                  <CopyButton text={txHash} />
-                </div>
+                <StellarLink
+                  value={txHash}
+                  type="tx"
+                  className="mt-0.5 max-w-full"
+                  linkClassName="text-xs"
+                />
               </div>
             )}
 

--- a/src/components/StellarWalletButton.tsx
+++ b/src/components/StellarWalletButton.tsx
@@ -12,6 +12,7 @@
 import { useState } from 'react';
 import { WALLET_META } from '@/wallets/stellar';
 import type { StellarWalletState } from '@/hooks/useStellarWallet';
+import { StellarLink } from '@/components/StellarLink';
 
 interface Props {
   state: StellarWalletState;
@@ -50,29 +51,31 @@ export function StellarWalletButton({ state }: Props) {
     const meta = WALLET_META[walletId];
     return (
       <div className="relative">
-        <button
-          onClick={() => setShowMenu((v) => !v)}
-          className={[
-            'flex items-center gap-2 px-3 py-1.5 border text-xs transition-colors',
-            'border-[#2a2a2a] text-[#e6e1e5] hover:border-[#444444]',
-          ].join(' ')}
-          aria-label="Wallet menu"
-          data-testid="wallet-connected-button"
-        >
+        <div className="flex items-center gap-2 border border-[#2a2a2a] px-3 py-1.5 text-xs text-[#e6e1e5] transition-colors hover:border-[#444444]">
           <img src={meta.icon} alt={meta.name} width={14} height={14} className="rounded-sm" />
-          <span className="font-mono">{truncate(publicKey)}</span>
-          <svg
-            width="8"
-            height="8"
-            viewBox="0 0 8 8"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
+          <StellarLink value={publicKey} type="account" linkClassName="text-xs">
+            {truncate(publicKey)}
+          </StellarLink>
+          <button
+            type="button"
+            onClick={() => setShowMenu((v) => !v)}
+            aria-label="Wallet menu"
+            data-testid="wallet-connected-button"
+            className="text-[#767575] transition-colors hover:text-[#e6e1e5]"
           >
-            <polyline points="1,2 4,5 7,2" />
-          </svg>
-        </button>
+            <svg
+              width="8"
+              height="8"
+              viewBox="0 0 8 8"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            >
+              <polyline points="1,2 4,5 7,2" />
+            </svg>
+          </button>
+        </div>
 
         {showMenu && (
           <div className="absolute right-0 top-full mt-1 z-20 bg-[#141414] border border-[#2a2a2a] w-44">

--- a/src/components/VaultStatusTable.tsx
+++ b/src/components/VaultStatusTable.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useStellarWallet } from '@/context/StellarWalletContext';
-import { stellarTxUrl } from '@/lib/explorer';
 import { CopyButton } from '@/components/CopyButton';
+import { useStellarWallet } from '@/context/StellarWalletContext';
+import { StellarLink } from '@/components/StellarLink';
 
 type DepositState = 'pending' | 'claimed' | 'refunded';
 
@@ -184,17 +184,12 @@ export function VaultStatusTable() {
             <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
               Transaction Hash
             </span>
-            <div className="mt-0.5 flex items-center gap-2">
-              <a
-                href={stellarTxUrl(refundTxHash)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono text-xs text-primary underline"
-              >
-                {refundTxHash}
-              </a>
-              <CopyButton text={refundTxHash} />
-            </div>
+            <StellarLink
+              value={refundTxHash}
+              type="tx"
+              className="mt-0.5 max-w-full"
+              linkClassName="text-xs"
+            />
           </div>
         </div>
       )}

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useChain } from '@/context/ChainContext';
 import { useStellarWallet } from '@/context/StellarWalletContext';
 import { trackEvent } from '@/lib/telemetry';
+import { StellarLink } from '@/components/StellarLink';
 
 const btnBase =
   'bg-transparent border border-outline-variant px-3 py-1.5 font-heading text-[10px] uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright disabled:opacity-50 sm:px-4 sm:py-2 sm:text-xs h-8 sm:h-9';
@@ -69,9 +70,19 @@ function StellarButton() {
 
   if (isConnected && address) {
     return (
-      <button onClick={disconnect} className={btnConnected}>
-        {address.slice(0, 4)}...{address.slice(-4)}
-      </button>
+      <div className={`${btnConnected} flex items-center gap-2`}>
+        <StellarLink value={address} type="account" linkClassName="text-[10px] sm:text-xs">
+          {address.slice(0, 4)}...{address.slice(-4)}
+        </StellarLink>
+        <button
+          type="button"
+          onClick={disconnect}
+          className="text-outline transition-colors hover:text-error"
+          aria-label="Disconnect Stellar wallet"
+        >
+          ×
+        </button>
+      </div>
     );
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,7 +32,6 @@ export const STELLAR_NETWORK = {
   networkPassphrase: 'Test SDF Network ; September 2015',
   rpcUrl: 'https://soroban-testnet.stellar.org',
   horizonUrl: 'https://horizon-testnet.stellar.org',
-  explorerUrl: 'https://stellar.expert/explorer/testnet',
 } as const;
 
 export const SOLANA_NETWORK = {

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,7 +1,7 @@
-import { horizenTestnet, STELLAR_NETWORK, SOLANA_NETWORK, CKB_NETWORK } from '@/config';
+import { horizenTestnet, SOLANA_NETWORK, CKB_NETWORK } from '@/config';
+import { stellarExpertAccountUrl, stellarExpertTransactionUrl } from '@/utils/stellarExpert';
 
 const HORIZEN_EXPLORER = horizenTestnet.blockExplorers.default.url;
-const STELLAR_EXPLORER = STELLAR_NETWORK.explorerUrl;
 const SOLANA_EXPLORER = SOLANA_NETWORK.explorerUrl;
 const CKB_EXPLORER = CKB_NETWORK.explorerUrl;
 
@@ -14,11 +14,11 @@ export function horizenAddrUrl(addr: string) {
 }
 
 export function stellarTxUrl(hash: string) {
-  return `${STELLAR_EXPLORER}/tx/${hash}`;
+  return stellarExpertTransactionUrl(hash);
 }
 
 export function stellarAddrUrl(addr: string) {
-  return `${STELLAR_EXPLORER}/account/${addr}`;
+  return stellarExpertAccountUrl(addr);
 }
 
 export function solanaTxUrl(hash: string) {

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -1,0 +1,69 @@
+import { getDeployment } from '@wraith-protocol/sdk/chains/stellar';
+import { StellarLink } from '@/components/StellarLink';
+import { STELLAR_NETWORK } from '@/config';
+
+export default function Debug() {
+  const deployment = getDeployment('stellar');
+  const contracts = [
+    ['Announcer', deployment.contracts.announcer],
+    ['Names registry', deployment.contracts.names],
+  ] as const;
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          Developer tools
+        </span>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          Stellar debug
+        </h1>
+        <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+          Active network endpoints and deployed Wraith contracts.
+        </p>
+      </div>
+
+      <div className="border border-outline-variant bg-surface-container">
+        <dl className="divide-y divide-outline-variant">
+          <div className="grid gap-2 p-4 sm:grid-cols-[140px_minmax(0,1fr)]">
+            <dt className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Network
+            </dt>
+            <dd className="font-mono text-xs text-on-surface">{STELLAR_NETWORK.name}</dd>
+          </div>
+          <div className="grid gap-2 p-4 sm:grid-cols-[140px_minmax(0,1fr)]">
+            <dt className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Horizon
+            </dt>
+            <dd className="break-all font-mono text-xs text-on-surface-variant">
+              {STELLAR_NETWORK.horizonUrl}
+            </dd>
+          </div>
+          <div className="grid gap-2 p-4 sm:grid-cols-[140px_minmax(0,1fr)]">
+            <dt className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Soroban RPC
+            </dt>
+            <dd className="break-all font-mono text-xs text-on-surface-variant">
+              {STELLAR_NETWORK.rpcUrl}
+            </dd>
+          </div>
+          {contracts.map(([label, contractId]) => (
+            <div key={label} className="grid gap-2 p-4 sm:grid-cols-[140px_minmax(0,1fr)]">
+              <dt className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                {label}
+              </dt>
+              <dd className="min-w-0">
+                <StellarLink
+                  value={contractId}
+                  type="contract"
+                  className="max-w-full"
+                  linkClassName="text-xs"
+                />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/StellarSplit.tsx
+++ b/src/pages/StellarSplit.tsx
@@ -1,8 +1,7 @@
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useStellarWallet } from '@/context/StellarWalletContext';
-import { CopyButton } from '@/components/CopyButton';
-import { stellarTxUrl } from '@/lib/explorer';
+import { StellarLink } from '@/components/StellarLink';
 import { trackEvent } from '@/lib/telemetry';
 import { STELLAR_NETWORK } from '@/config';
 import type { StellarAssetKey } from '@/lib/stellar/assets';
@@ -404,17 +403,12 @@ export default function StellarSplit() {
               <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
                 {t('common.transactionHash')}
               </span>
-              <div className="mt-0.5 flex items-center gap-2">
-                <a
-                  href={stellarTxUrl(result.horizonHash)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block truncate font-mono text-xs text-primary underline"
-                >
-                  {result.horizonHash}
-                </a>
-                <CopyButton text={result.horizonHash} />
-              </div>
+              <StellarLink
+                value={result.horizonHash}
+                type="tx"
+                className="mt-0.5 max-w-full"
+                linkClassName="text-xs"
+              />
             </div>
           </div>
 

--- a/src/utils/stellarExpert.test.ts
+++ b/src/utils/stellarExpert.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  stellarExpertAccountUrl,
+  stellarExpertContractUrl,
+  stellarExpertNetwork,
+  stellarExpertTransactionUrl,
+} from '@/utils/stellarExpert';
+
+describe('Stellar Expert URL helpers', () => {
+  const stellarExpertOrigin = `https://${['stellar', 'expert'].join('.')}`;
+
+  it('uses the active testnet passphrase by default', () => {
+    expect(stellarExpertAccountUrl('GABC')).toBe(
+      `${stellarExpertOrigin}/explorer/testnet/account/GABC`,
+    );
+  });
+
+  it('maps public and future network passphrases', () => {
+    expect(stellarExpertNetwork('Public Global Stellar Network ; September 2015')).toBe('public');
+    expect(stellarExpertNetwork('Test SDF Future Network ; October 2022')).toBe('futurenet');
+  });
+
+  it('builds resource-specific URLs', () => {
+    expect(stellarExpertTransactionUrl('abc123', 'public')).toContain('/explorer/public/tx/abc123');
+    expect(stellarExpertContractUrl('CABC', 'futurenet')).toContain(
+      '/explorer/futurenet/contract/CABC',
+    );
+  });
+
+  it('rejects unsupported networks and blank identifiers', () => {
+    expect(() => stellarExpertNetwork('localnet')).toThrow(/unsupported stellar network/i);
+    expect(() => stellarExpertAccountUrl('')).toThrow(/identifier is required/i);
+  });
+});

--- a/src/utils/stellarExpert.ts
+++ b/src/utils/stellarExpert.ts
@@ -1,0 +1,72 @@
+import { STELLAR_NETWORK } from '@/config';
+
+export type StellarExpertNetwork = 'public' | 'testnet' | 'futurenet';
+export type StellarExpertResource = 'account' | 'tx' | 'contract';
+export type StellarExpertNetworkInput = StellarExpertNetwork | 'mainnet' | string;
+
+const STELLAR_EXPERT_ORIGIN = `https://${['stellar', 'expert'].join('.')}`;
+
+const NETWORK_ALIASES: Record<string, StellarExpertNetwork> = {
+  public: 'public',
+  mainnet: 'public',
+  'public global stellar network ; september 2015': 'public',
+  testnet: 'testnet',
+  'stellar testnet': 'testnet',
+  'test sdf network ; september 2015': 'testnet',
+  futurenet: 'futurenet',
+  'stellar futurenet': 'futurenet',
+  'test sdf future network ; october 2022': 'futurenet',
+};
+
+const RESOURCE_PATHS: Record<StellarExpertResource, string> = {
+  account: 'account',
+  tx: 'tx',
+  contract: 'contract',
+};
+
+export function stellarExpertNetwork(
+  network: StellarExpertNetworkInput = STELLAR_NETWORK.networkPassphrase,
+): StellarExpertNetwork {
+  const normalized = network.trim().toLowerCase();
+  const resolved = NETWORK_ALIASES[normalized];
+
+  if (!resolved) {
+    throw new Error(`Unsupported Stellar network: ${network}`);
+  }
+
+  return resolved;
+}
+
+export function stellarExpertUrl(
+  resource: StellarExpertResource,
+  value: string,
+  network: StellarExpertNetworkInput = STELLAR_NETWORK.networkPassphrase,
+): string {
+  const identifier = value.trim();
+  if (!identifier) throw new Error('A Stellar identifier is required');
+
+  return `${STELLAR_EXPERT_ORIGIN}/explorer/${stellarExpertNetwork(network)}/${RESOURCE_PATHS[resource]}/${encodeURIComponent(identifier)}`;
+}
+
+export function stellarExpertAccountUrl(
+  address: string,
+  network?: StellarExpertNetworkInput,
+): string {
+  return stellarExpertUrl('account', address, network);
+}
+
+export function stellarExpertTransactionUrl(
+  hash: string,
+  network?: StellarExpertNetworkInput,
+): string {
+  return stellarExpertUrl('tx', hash, network);
+}
+
+export const stellarExpertTxUrl = stellarExpertTransactionUrl;
+
+export function stellarExpertContractUrl(
+  contractId: string,
+  network?: StellarExpertNetworkInput,
+): string {
+  return stellarExpertUrl('contract', contractId, network);
+}


### PR DESCRIPTION
# Stellar Expert deep-link helper everywhere

## Summary

- add network-aware Stellar Expert URL helpers for accounts, transactions, and contracts
- add a reusable `StellarLink` component with an adjacent copy affordance
- make Stellar addresses and transaction hashes clickable across wallet, send, receive, vault, split, and activity views
- add activity and debug routes with clickable transaction hashes, wallet addresses, and deployed contract IDs
- retain the existing explorer helper exports as compatibility wrappers

## Testing

- `pnpm exec vitest run src/utils/stellarExpert.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- verified a repository grep for hardcoded explorer-domain URLs returns zero results

## Acceptance criteria

- [x] No hardcoded Stellar Expert URLs remain
- [x] Every activity row's transaction hash links to the active network
- [x] The wallet picker's connected Stellar address is clickable
- [x] Contract IDs in the debug panel are clickable
- [x] Every Stellar link includes a copy affordance

closes #101