### PR TITLE
feat(stellar): add send QR scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@walletconnect/core": "^2.23.10",
     "@walletconnect/sign-client": "^2.23.10",
     "@wraith-protocol/sdk": "^1.4.5",
+    "@zxing/browser": "0.0.7",
     "bs58": "^6.0.0",
     "buffer": "^6.0.3",
     "i18next": "^24.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@wraith-protocol/sdk':
         specifier: ^1.4.5
         version: 1.4.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6))(@stellar/stellar-sdk@13.3.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)(zod@4.3.6)
+      '@zxing/browser':
+        specifier: 0.0.7
+        version: 0.0.7(@zxing/library@0.18.6)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0

--- a/src/components/QRCodeModal.tsx
+++ b/src/components/QRCodeModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { CopyButton } from '@/components/CopyButton';
 
@@ -6,10 +6,19 @@ interface QRCodeModalProps {
   value: string;
   onClose: () => void;
   title?: string;
+  variants?: Array<{ label: string; value: string }>;
 }
 
-export function QRCodeModal({ value, onClose, title = 'Stealth Meta-Address' }: QRCodeModalProps) {
+export function QRCodeModal({
+  value,
+  onClose,
+  title = 'Stealth Meta-Address',
+  variants,
+}: QRCodeModalProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const [selectedVariant, setSelectedVariant] = useState(0);
+  const qrVariants = variants?.length ? variants : [{ label: 'Meta-address', value }];
+  const activeVariant = qrVariants[Math.min(selectedVariant, qrVariants.length - 1)];
 
   // Close on Escape key press, and focus close button on mount
   useEffect(() => {
@@ -34,7 +43,7 @@ export function QRCodeModal({ value, onClose, title = 'Stealth Meta-Address' }: 
       try {
         await navigator.share({
           title: title,
-          text: value,
+          text: activeVariant.value,
         });
       } catch (err) {
         console.error('Error sharing:', err);
@@ -42,7 +51,7 @@ export function QRCodeModal({ value, onClose, title = 'Stealth Meta-Address' }: 
     } else {
       // Fallback: Copy to clipboard
       try {
-        await navigator.clipboard.writeText(value);
+        await navigator.clipboard.writeText(activeVariant.value);
       } catch (err) {
         console.error('Failed to copy address:', err);
       }
@@ -88,15 +97,38 @@ export function QRCodeModal({ value, onClose, title = 'Stealth Meta-Address' }: 
         </div>
 
         <div className="flex flex-col items-center gap-4">
+          {qrVariants.length > 1 && (
+            <div
+              className="grid w-full grid-cols-2 border border-outline-variant"
+              aria-label="QR code format"
+            >
+              {qrVariants.map((variant, index) => (
+                <button
+                  key={variant.label}
+                  type="button"
+                  onClick={() => setSelectedVariant(index)}
+                  aria-pressed={selectedVariant === index}
+                  className={`px-3 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors ${
+                    selectedVariant === index
+                      ? 'bg-primary text-surface'
+                      : 'text-outline hover:text-primary'
+                  }`}
+                >
+                  {variant.label}
+                </button>
+              ))}
+            </div>
+          )}
+
           <div className="rounded-lg bg-white p-4">
-            <QRCodeSVG value={value} size={200} />
+            <QRCodeSVG value={activeVariant.value} size={200} />
           </div>
 
           <div className="flex w-full items-center gap-2 rounded bg-surface p-2 border border-outline-variant">
             <code className="block flex-1 truncate font-mono text-[10px] text-primary">
-              {value}
+              {activeVariant.value}
             </code>
-            <CopyButton text={value} />
+            <CopyButton text={activeVariant.value} />
           </div>
 
           <div className="flex w-full gap-2 mt-2">

--- a/src/components/StellarReceive.tsx
+++ b/src/components/StellarReceive.tsx
@@ -40,6 +40,7 @@ import { STELLAR_ASSETS, getAssetByKey, parseAssetBalances } from '@/lib/stellar
 import { useStellarNotifications } from '@/hooks/useStellarNotifications';
 import { useStealthLabels } from '@/hooks/useStealthLabels';
 import { StellarBatchWithdrawModal } from '@/components/StellarBatchWithdrawModal';
+import { createStellarQrUri } from '@/utils/qr';
 
 const ANNOUNCER_CONTRACT = 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
 const REGISTRY_CONTRACT = 'CC2LAUCXYOPJ4DV4CYXNXYAXRDVOTMAWFF76W4WFD5OVQBD6TN4PYYJ5';
@@ -1450,7 +1451,14 @@ export function StellarReceive() {
         }
       />
       {showQRModal && stellarMetaAddress && (
-        <QRCodeModal value={stellarMetaAddress} onClose={() => setShowQRModal(false)} />
+        <QRCodeModal
+          value={stellarMetaAddress}
+          variants={[
+            { label: 'Meta-address', value: stellarMetaAddress },
+            { label: 'Stellar URI', value: createStellarQrUri(stellarMetaAddress) },
+          ]}
+          onClose={() => setShowQRModal(false)}
+        />
       )}
       <StellarBatchWithdrawModal
         isOpen={isBatchModalOpen}

--- a/src/components/StellarSend.tsx
+++ b/src/components/StellarSend.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck  (temporary: wave-6 merges left stale symbol names; unblocks CI)
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { QrReader } from 'react-qr-reader';
 import {
   TransactionBuilder,
   Account,
@@ -37,6 +38,7 @@ import {
 } from '@/lib/stellarSimulation';
 import { useActivityStore } from '@/stores/activityStore';
 import { ExpiringNamesBanner } from '@/components/ExpiringNamesBanner';
+import { decodeQrImage, isCameraUnavailableError, parseStellarQrPayload } from '@/utils/qr';
 
 const ANNOUNCER_CONTRACT = 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
 const STELLAR_BASE_FEE_XLM = 0.00001;
@@ -117,8 +119,11 @@ export function StellarSend() {
   const [, setSubmitAttempted] = useState(false);
 
   const [isScanningQR, setIsScanningQR] = useState(false);
-  const [, setScannerError] = useState('');
+  const [scannerError, setScannerError] = useState('');
+  const [cameraUnavailable, setCameraUnavailable] = useState(false);
+  const [isDecodingQrImage, setIsDecodingQrImage] = useState(false);
   const closeScannerRef = useRef<HTMLButtonElement>(null);
+  const qrImageInputRef = useRef<HTMLInputElement>(null);
 
   // Focus close button on mount and handle Escape key to close
   useEffect(() => {
@@ -140,38 +145,61 @@ export function StellarSend() {
     }
   }, [isScanningQR]);
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const _handleScanResult = useCallback((result: any, _error: any) => {
-    if (result) {
-      const text = result.text?.trim();
-      if (!text) return;
-
-      // 1. Check if it's a payment link
-      try {
-        const url = new URL(text);
-        const toParam = url.searchParams.get('to');
-        if (toParam && toParam.startsWith('st:xlm:')) {
-          setRecipient(toParam);
-          const amtParam = url.searchParams.get('amount');
-          if (amtParam) setAmount(amtParam);
-          const memoParam = url.searchParams.get('memo');
-          if (memoParam) setMemo(memoParam);
-          setIsScanningQR(false);
-          return;
-        }
-      } catch {
-        // Not a URL, continue checking if it's a raw meta-address
-      }
-
-      // 2. Check if it's a raw meta-address
-      if (text.startsWith('st:xlm:')) {
-        setRecipient(text);
-        setIsScanningQR(false);
-      } else {
-        setScannerError('Invalid QR code. Must be a stealth meta-address or payment link.');
-      }
+  const applyQrPayload = useCallback((text: string) => {
+    try {
+      const payload = parseStellarQrPayload(text);
+      setRecipient(payload.metaAddress);
+      if (payload.amount) setAmount(payload.amount);
+      if (payload.memo) setMemo(payload.memo);
+      setTouched((previous) => ({ ...previous, recipient: true }));
+      setScannerError('');
+      setIsScanningQR(false);
+    } catch (scanError) {
+      setScannerError(
+        scanError instanceof Error ? scanError.message : 'This QR code could not be read.',
+      );
     }
   }, []);
+
+  const handleScanResult = useCallback(
+    (result: any, scanError: any) => {
+      const text = result?.getText?.() ?? result?.text;
+      if (text) {
+        applyQrPayload(text);
+        return;
+      }
+
+      if (isCameraUnavailableError(scanError)) {
+        setCameraUnavailable(true);
+        setScannerError('Camera access is unavailable. Choose a saved QR image to continue.');
+      }
+    },
+    [applyQrPayload],
+  );
+
+  const openQrScanner = () => {
+    setScannerError('');
+    setCameraUnavailable(false);
+    setIsScanningQR(true);
+  };
+
+  const handleQrImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsDecodingQrImage(true);
+    setScannerError('');
+    try {
+      applyQrPayload(await decodeQrImage(file));
+    } catch (scanError) {
+      setScannerError(
+        scanError instanceof Error ? scanError.message : 'This QR image could not be read.',
+      );
+    } finally {
+      setIsDecodingQrImage(false);
+      event.target.value = '';
+    }
+  };
 
   const [sourceBalance, setSourceBalance] = useState<number | null>(null);
   const [isBalanceLoading, setIsBalanceLoading] = useState(false);
@@ -725,20 +753,30 @@ export function StellarSend() {
             <label className="font-mono text-[10px] uppercase tracking-widest text-outline">
               {t('common.recipientMetaAddress')}
             </label>
-            <div className="relative">
+            <div className="flex flex-col gap-2">
               <input
                 type="text"
                 value={recipient}
                 onChange={(e) => setRecipient(e.target.value)}
                 placeholder={t('stellar.recipientPlaceholder')}
-                className="h-12 w-full border border-outline-variant bg-surface px-4 pr-20 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
+                className="h-12 w-full border border-outline-variant bg-surface px-4 font-mono text-sm text-primary placeholder:text-outline focus:border-primary"
               />
-              <button
-                onClick={handlePaste}
-                className="absolute right-3 top-1/2 -translate-y-1/2 font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
-              >
-                {t('common.paste')}
-              </button>
+              <div className="flex justify-end gap-4">
+                <button
+                  type="button"
+                  onClick={handlePaste}
+                  className="font-heading text-[10px] uppercase tracking-widest text-outline transition-colors hover:text-primary"
+                >
+                  {t('common.paste')}
+                </button>
+                <button
+                  type="button"
+                  onClick={openQrScanner}
+                  className="font-heading text-[10px] uppercase tracking-widest text-primary transition-colors hover:brightness-110"
+                >
+                  Scan QR
+                </button>
+              </div>
             </div>
           </div>
 
@@ -910,6 +948,84 @@ export function StellarSend() {
               {t('common.newTransfer')}
             </button>
           )}
+        </div>
+      )}
+
+      {isScanningQR && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="qr-scanner-title"
+        >
+          <div className="flex w-full max-w-sm flex-col gap-4 border border-outline-variant bg-surface-container p-5 shadow-xl">
+            <div className="flex items-center justify-between">
+              <h2
+                id="qr-scanner-title"
+                className="font-heading text-lg font-bold uppercase tracking-tight text-on-surface"
+              >
+                Scan recipient QR
+              </h2>
+              <button
+                ref={closeScannerRef}
+                type="button"
+                onClick={() => setIsScanningQR(false)}
+                aria-label="Close QR scanner"
+                className="p-1 text-outline transition-colors hover:text-primary"
+              >
+                ×
+              </button>
+            </div>
+
+            {!cameraUnavailable && (
+              <div className="overflow-hidden bg-black">
+                <QrReader
+                  constraints={{ facingMode: { ideal: 'environment' } }}
+                  scanDelay={300}
+                  onResult={handleScanResult}
+                  containerStyle={{ width: '100%' }}
+                  videoStyle={{ width: '100%', height: 'auto' }}
+                />
+              </div>
+            )}
+
+            {cameraUnavailable && (
+              <div className="border border-error/40 bg-error/10 p-3">
+                <p className="font-body text-sm text-error">
+                  Camera permission was denied or the camera is unavailable.
+                </p>
+                <p className="mt-1 font-body text-xs text-on-surface-variant">
+                  Select a screenshot or saved QR image instead.
+                </p>
+              </div>
+            )}
+
+            {scannerError && !cameraUnavailable && (
+              <p role="alert" className="font-body text-sm text-error">
+                {scannerError}
+              </p>
+            )}
+
+            <input
+              ref={qrImageInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleQrImage}
+              className="hidden"
+              aria-label="Choose a QR code image"
+            />
+            <button
+              type="button"
+              onClick={() => qrImageInputRef.current?.click()}
+              disabled={isDecodingQrImage}
+              className="h-11 w-full border border-outline-variant font-heading text-[11px] font-semibold uppercase tracking-widest text-primary transition-colors hover:bg-surface-bright disabled:opacity-50"
+            >
+              {isDecodingQrImage ? 'Reading image...' : 'Choose QR image'}
+            </button>
+            <p className="font-body text-[11px] leading-relaxed text-outline">
+              QR images are decoded locally in your browser and are never uploaded.
+            </p>
+          </div>
         </div>
       )}
     </section>

--- a/src/utils/qr.test.ts
+++ b/src/utils/qr.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createStellarQrUri, isCameraUnavailableError, parseStellarQrPayload } from '@/utils/qr';
+
+const META_ADDRESS =
+  'st:xlm:5a1922b5614eed2ef72ebad40abc5d014f7c27b6e1de5dc36976e9eec4cbe29e6b912a495f9f14513d54a00a7887f986d394a30a77239475caf211e8094b6cdb';
+
+describe('Stellar QR payloads', () => {
+  it('round-trips a receive meta-address through a stellar URI', () => {
+    const uri = createStellarQrUri(META_ADDRESS);
+
+    expect(uri).toMatch(/^stellar:pay\?/);
+    expect(parseStellarQrPayload(uri)).toEqual({ metaAddress: META_ADDRESS });
+  });
+
+  it('accepts a raw meta-address', () => {
+    expect(parseStellarQrPayload(META_ADDRESS)).toEqual({ metaAddress: META_ADDRESS });
+  });
+
+  it('reads optional payment fields and common recipient parameter names', () => {
+    const uri = `stellar:pay?destination=${encodeURIComponent(META_ADDRESS)}&amount=12.5&memo=Invoice`;
+
+    expect(parseStellarQrPayload(uri)).toEqual({
+      metaAddress: META_ADDRESS,
+      amount: '12.5',
+      memo: 'Invoice',
+    });
+  });
+
+  it('preserves support for browser payment links', () => {
+    const link = `https://example.test/pay?to=${encodeURIComponent(META_ADDRESS)}&amount=4`;
+
+    expect(parseStellarQrPayload(link)).toEqual({
+      metaAddress: META_ADDRESS,
+      amount: '4',
+    });
+  });
+
+  it('rejects unrelated QR content', () => {
+    expect(() => parseStellarQrPayload('https://example.test/no-recipient')).toThrow(
+      /meta-address/i,
+    );
+    expect(() => parseStellarQrPayload('not a payment')).toThrow(/supported stellar/i);
+  });
+
+  it('recognizes denied camera permission without treating scan misses as denial', () => {
+    const denied = new DOMException('Permission denied', 'NotAllowedError');
+    const scanMiss = new Error('No QR code found');
+    scanMiss.name = 'NotFoundException';
+
+    expect(isCameraUnavailableError(denied)).toBe(true);
+    expect(isCameraUnavailableError(scanMiss)).toBe(false);
+  });
+});

--- a/src/utils/qr.ts
+++ b/src/utils/qr.ts
@@ -1,0 +1,92 @@
+export interface StellarQrPayload {
+  metaAddress: string;
+  amount?: string;
+  memo?: string;
+}
+
+const META_ADDRESS_PREFIX = 'st:xlm:';
+const SUPPORTED_PROTOCOLS = new Set(['stellar:', 'web+stellar:', 'http:', 'https:']);
+const CAMERA_UNAVAILABLE_ERRORS = new Set([
+  'AbortError',
+  'NotAllowedError',
+  'NotFoundError',
+  'NotReadableError',
+  'OverconstrainedError',
+  'SecurityError',
+]);
+
+function assertMetaAddress(value: string | null): string {
+  const metaAddress = value?.trim() ?? '';
+  if (!metaAddress.startsWith(META_ADDRESS_PREFIX)) {
+    throw new Error('QR code does not contain a Stellar stealth meta-address');
+  }
+  return metaAddress;
+}
+
+export function createStellarQrUri(metaAddress: string): string {
+  const params = new URLSearchParams({ to: assertMetaAddress(metaAddress) });
+  return `stellar:pay?${params.toString()}`;
+}
+
+export function parseStellarQrPayload(value: string): StellarQrPayload {
+  const payload = value.trim();
+  if (payload.startsWith(META_ADDRESS_PREFIX)) {
+    return { metaAddress: payload };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(payload);
+  } catch {
+    throw new Error('QR code is not a supported Stellar payment payload');
+  }
+
+  if (!SUPPORTED_PROTOCOLS.has(url.protocol)) {
+    throw new Error('QR code uses an unsupported protocol');
+  }
+
+  if (
+    (url.protocol === 'stellar:' || url.protocol === 'web+stellar:') &&
+    url.pathname.replace(/^\/+/, '') !== 'pay'
+  ) {
+    throw new Error('QR code is not a Stellar payment URI');
+  }
+
+  const metaAddress = assertMetaAddress(
+    url.searchParams.get('to') ??
+      url.searchParams.get('recipient') ??
+      url.searchParams.get('destination'),
+  );
+  const amount = url.searchParams.get('amount')?.trim();
+  const memo = url.searchParams.get('memo')?.trim();
+
+  return {
+    metaAddress,
+    ...(amount ? { amount } : {}),
+    ...(memo ? { memo } : {}),
+  };
+}
+
+export function isCameraUnavailableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const name = 'name' in error && typeof error.name === 'string' ? error.name : '';
+  const message = 'message' in error && typeof error.message === 'string' ? error.message : '';
+  return CAMERA_UNAVAILABLE_ERRORS.has(name) || message.includes('MediaDevices API has no support');
+}
+
+export async function decodeQrImage(file: File): Promise<string> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Choose an image containing a QR code');
+  }
+
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const { BrowserQRCodeReader } = await import('@zxing/browser');
+    const result = await new BrowserQRCodeReader().decodeFromImageUrl(objectUrl);
+    return result.getText();
+  } catch {
+    throw new Error('No readable QR code was found in that image');
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}


### PR DESCRIPTION
# QR code scanner for send flow

## Summary

- add raw meta-address and `stellar:` URI QR variants to the Stellar receive flow
- add a mobile-friendly camera scanner to the Stellar send form
- populate recipient, amount, and memo fields from supported QR payloads
- show a file-picker fallback when camera permission is denied or unavailable
- decode selected QR images entirely in the browser without uploading them
- add shared QR parsing, URI generation, permission classification, and image-decoding utilities

## Testing

- `pnpm exec vitest run src/utils/qr.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `git diff --check`

## Acceptance criteria

- [x] Receive view offers QR codes for the raw meta-address and Stellar URI
- [x] Send view scans with the device camera and fills the recipient
- [x] Raw meta-addresses and Stellar URIs are accepted
- [x] Camera denial or unavailability displays the image fallback
- [x] Receive-generated Stellar URIs round-trip through the send parser
- [x] Selected images are decoded locally and never uploaded

closes #108