### PR TITLE
feat(names): add auction bidding, watchlist, and settlement UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useNotificationSW } from '@/hooks/useNotificationSW';
 import Schedule from '@/pages/Schedule';
 import StellarSplit from '@/pages/StellarSplit';
 import Names from '@/pages/Names';
+import NamesAuctions from '@/pages/NamesAuctions';
 import Activity from '@/pages/Activity';
 import Debug from '@/pages/Debug';
 
@@ -37,6 +38,7 @@ export function App() {
           <Route path="/stellar/split" element={<StellarSplit />} />
           <Route path="/pay" element={<Send />} />
           <Route path="/names" element={<Names />} />
+          <Route path="/names/auctions" element={<NamesAuctions />} />
           <Route path="/activity" element={<Activity />} />
           <Route path="/history" element={<Activity />} />
           <Route path="/debug" element={<Debug />} />

--- a/src/lib/stellar/names.ts
+++ b/src/lib/stellar/names.ts
@@ -3,14 +3,17 @@ import {
   Account,
   Contract,
   nativeToScVal,
+  scValToNative,
   Address,
   xdr,
 } from '@stellar/stellar-sdk';
+import { Buffer } from 'buffer';
 import { STELLAR_NETWORK } from '@/config';
 
-// Wraith Names contract ID on Stellar Testnet
-// TODO: Replace with actual contract ID from deployment
-export const NAMES_CONTRACT_ID = 'CD3Z7J2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
+// Override for futurenet recordings or a new deployment without rebuilding this module.
+export const NAMES_CONTRACT_ID =
+  import.meta.env.VITE_WRAITH_NAMES_CONTRACT_ID ||
+  'CD3Z7J2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
 
 export interface NameMetadata {
   avatar_url?: string;
@@ -43,6 +46,236 @@ export interface RenewParams {
 export interface MetadataParams {
   name: string;
   metadata: NameMetadata;
+}
+
+export interface NameAuction {
+  name: string;
+  commitEnd: number;
+  revealEnd: number;
+  highestBidder: string | null;
+  highestAmount: bigint;
+  settled: boolean;
+}
+
+export interface NameAuctionConfig {
+  reservePrice: bigint;
+  minBidIncrement: bigint;
+  commitSecs: number;
+  revealSecs: number;
+}
+
+export interface CommitBidParams {
+  name: string;
+  commitmentHex: string;
+  deposit: bigint;
+}
+
+export interface RevealBidParams {
+  name: string;
+  amount: bigint;
+  saltHex: string;
+}
+
+export const MIN_AUCTION_BID_INCREMENT = 1_000_000n; // 0.1 XLM in stroops
+
+async function getSourceAccount(fromAddress: string) {
+  const accountRes = await fetch(`${STELLAR_NETWORK.horizonUrl}/accounts/${fromAddress}`);
+  if (!accountRes.ok) throw new Error('Failed to load account');
+  const accountData = (await accountRes.json()) as { sequence: string };
+  return new Account(fromAddress, accountData.sequence);
+}
+
+async function simulateRead<T>(operation: xdr.Operation): Promise<T> {
+  const { rpc } = await import('@stellar/stellar-sdk');
+  const server = new rpc.Server(STELLAR_NETWORK.rpcUrl);
+  const tx = new TransactionBuilder(
+    new Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWH', '0'),
+    { fee: '100', networkPassphrase: STELLAR_NETWORK.networkPassphrase },
+  )
+    .addOperation(operation)
+    .setTimeout(30)
+    .build();
+  const simulation = await server.simulateTransaction(tx);
+  if ('error' in simulation) throw new Error(simulation.error);
+  if (!simulation.result) throw new Error('Contract returned no result');
+  return scValToNative(simulation.result.retval) as T;
+}
+
+async function buildAuctionTransaction(fromAddress: string, operation: xdr.Operation) {
+  const { rpc } = await import('@stellar/stellar-sdk');
+  const server = new rpc.Server(STELLAR_NETWORK.rpcUrl);
+  const sourceAccount = await getSourceAccount(fromAddress);
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: '100',
+    networkPassphrase: STELLAR_NETWORK.networkPassphrase,
+  })
+    .addOperation(operation)
+    .setTimeout(30)
+    .build();
+  const simulation = await server.simulateTransaction(tx);
+  if ('error' in simulation) throw new Error(simulation.error);
+  return rpc.assembleTransaction(tx, simulation).build().toXDR();
+}
+
+function bytesScVal(hex: string) {
+  const normalized = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (!/^[0-9a-f]{64}$/i.test(normalized)) throw new Error('Expected a 32-byte hex value');
+  return xdr.ScVal.scvBytes(Buffer.from(normalized, 'hex'));
+}
+
+function normalizeAuction(value: Record<string, unknown> | null): NameAuction | null {
+  if (!value) return null;
+  return {
+    name: String(value.name ?? ''),
+    commitEnd: Number(value.commit_end ?? 0),
+    revealEnd: Number(value.reveal_end ?? 0),
+    highestBidder: value.highest_bidder ? String(value.highest_bidder) : null,
+    highestAmount: BigInt(String(value.highest_amount ?? 0)),
+    settled: Boolean(value.settled),
+  };
+}
+
+export async function getNameAuction(name: string): Promise<NameAuction | null> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  const value = await simulateRead<Record<string, unknown> | null>(
+    contract.call('get_auction', nativeToScVal(name.trim().toLowerCase())),
+  );
+  return normalizeAuction(value);
+}
+
+export async function getNameAuctionConfig(): Promise<NameAuctionConfig | null> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  const value = await simulateRead<Record<string, unknown> | null>(contract.call('auction_config'));
+  if (!value) return null;
+  return {
+    reservePrice: BigInt(String(value.reserve_price ?? 0)),
+    minBidIncrement: BigInt(
+      String(value.min_increment ?? value.min_bid_increment ?? MIN_AUCTION_BID_INCREMENT),
+    ),
+    commitSecs: Number(value.commit_secs ?? 0),
+    revealSecs: Number(value.reveal_secs ?? 0),
+  };
+}
+
+export async function getActiveNameAuctions(names: string[]): Promise<NameAuction[]> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  try {
+    const values = await simulateRead<Array<Record<string, unknown>>>(
+      contract.call('get_active_auctions'),
+    );
+    if (Array.isArray(values)) {
+      return values
+        .map((value) => normalizeAuction(value))
+        .filter((auction): auction is NameAuction => auction !== null);
+    }
+  } catch {
+    // Current sealed-bid deployments expose lookup-by-name only. Fall back to
+    // the locally tracked names while remaining compatible with enumerable ABIs.
+  }
+
+  const uniqueNames = [...new Set(names.map((name) => name.trim().toLowerCase()).filter(Boolean))];
+  const auctions = await Promise.all(
+    uniqueNames.map(async (name) => {
+      try {
+        return await getNameAuction(name);
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return auctions.filter((auction): auction is NameAuction => auction !== null);
+}
+
+export async function computeNameBidCommitment(
+  bidder: string,
+  name: string,
+  amount: bigint,
+  saltHex: string,
+): Promise<string> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  const commitment = await simulateRead<Uint8Array>(
+    contract.call(
+      'compute_commitment',
+      nativeToScVal(name.trim().toLowerCase()),
+      new Address(bidder).toScVal(),
+      nativeToScVal(amount, { type: 'i128' }),
+      bytesScVal(saltHex),
+    ),
+  );
+  return Buffer.from(commitment).toString('hex');
+}
+
+export async function buildCommitNameBidTransaction(
+  bidder: string,
+  params: CommitBidParams,
+): Promise<string> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  return buildAuctionTransaction(
+    bidder,
+    contract.call(
+      'commit_bid',
+      new Address(bidder).toScVal(),
+      nativeToScVal(params.name.trim().toLowerCase()),
+      bytesScVal(params.commitmentHex),
+      nativeToScVal(params.deposit, { type: 'i128' }),
+    ),
+  );
+}
+
+export async function buildRevealNameBidTransaction(
+  bidder: string,
+  params: RevealBidParams,
+): Promise<string> {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  return buildAuctionTransaction(
+    bidder,
+    contract.call(
+      'reveal_bid',
+      new Address(bidder).toScVal(),
+      nativeToScVal(params.name.trim().toLowerCase()),
+      nativeToScVal(params.amount, { type: 'i128' }),
+      bytesScVal(params.saltHex),
+    ),
+  );
+}
+
+export async function buildSettleNameAuctionTransaction(fromAddress: string, name: string) {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  return buildAuctionTransaction(
+    fromAddress,
+    contract.call('settle_auction', nativeToScVal(name.trim().toLowerCase())),
+  );
+}
+
+export async function buildRefundNameBidTransaction(bidder: string, name: string) {
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  return buildAuctionTransaction(
+    bidder,
+    contract.call(
+      'withdraw_bid',
+      new Address(bidder).toScVal(),
+      nativeToScVal(name.trim().toLowerCase()),
+    ),
+  );
+}
+
+export async function buildClaimAuctionNameTransaction(
+  winner: string,
+  name: string,
+  stealthMetaAddress: Uint8Array,
+) {
+  if (stealthMetaAddress.length !== 64)
+    throw new Error('A 64-byte stealth meta-address is required');
+  const contract = new Contract(NAMES_CONTRACT_ID);
+  return buildAuctionTransaction(
+    winner,
+    contract.call(
+      'claim_name',
+      new Address(winner).toScVal(),
+      nativeToScVal(name.trim().toLowerCase()),
+      xdr.ScVal.scvBytes(Buffer.from(stealthMetaAddress)),
+    ),
+  );
 }
 
 /**

--- a/src/pages/Names.tsx
+++ b/src/pages/Names.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { useStellarWallet } from '@/context/StellarWalletContext';
 import { stellarTxUrl } from '@/lib/explorer';
 import {
@@ -13,6 +14,7 @@ import {
   type NameMetadata,
 } from '@/lib/stellar/names';
 import { CopyButton } from '@/components/CopyButton';
+import { useNameWatchlistStore } from '@/store/nameWatchlistStore';
 
 const DEFAULT_REGISTRATION_DURATION = 365 * 24 * 60 * 60; // 1 year in seconds
 
@@ -32,6 +34,11 @@ export default function Names() {
   const [error, setError] = useState('');
   const [txHash, setTxHash] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
+  const watchedAuctions = useNameWatchlistStore((state) => state.watchedAuctions);
+  const now = Math.floor(Date.now() / 1000);
+  const endingSoonAuctions = watchedAuctions.filter(
+    (auction) => auction.endsAt > now && auction.endsAt - now < 24 * 60 * 60,
+  );
 
   // Register form
   const [registerName, setRegisterName] = useState('');
@@ -267,7 +274,35 @@ export default function Names() {
         <p className="font-body text-sm leading-relaxed text-on-surface-variant">
           Register, transfer, and manage your Wraith Names. Set metadata to customize your identity.
         </p>
+        <Link
+          to="/names/auctions"
+          className="mt-2 w-fit font-heading text-[10px] font-semibold uppercase tracking-widest text-primary underline"
+        >
+          Browse name auctions
+        </Link>
       </div>
+
+      {endingSoonAuctions.length > 0 && (
+        <div className="border border-tertiary bg-surface-container p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <span className="font-heading text-xs font-semibold uppercase tracking-widest text-on-surface">
+                Watched auctions ending soon
+              </span>
+              <p className="mt-2 font-body text-sm text-on-surface-variant">
+                {endingSoonAuctions.map((auction) => `${auction.name}.wraith`).join(', ')}{' '}
+                {endingSoonAuctions.length === 1 ? 'ends' : 'end'} in under 24 hours.
+              </p>
+            </div>
+            <Link
+              to="/names/auctions"
+              className="shrink-0 font-heading text-[10px] uppercase tracking-widest text-primary underline"
+            >
+              View
+            </Link>
+          </div>
+        </div>
+      )}
 
       {/* Tabs */}
       <div className="flex gap-0 border-b border-outline-variant">

--- a/src/pages/NamesAuctions.tsx
+++ b/src/pages/NamesAuctions.tsx
@@ -1,0 +1,555 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { decodeStealthMetaAddress } from '@wraith-protocol/sdk/chains/stellar';
+import { useStellarWallet } from '@/context/StellarWalletContext';
+import { useStealthKeys } from '@/context/StealthKeysContext';
+import { useContacts } from '@/store/contactsStore';
+import { useNameHistory } from '@/store/nameHistoryStore';
+import { useNameWatchlistStore } from '@/store/nameWatchlistStore';
+import { stellarTxUrl } from '@/lib/explorer';
+import {
+  MIN_AUCTION_BID_INCREMENT,
+  NAMES_CONTRACT_ID,
+  buildClaimAuctionNameTransaction,
+  buildCommitNameBidTransaction,
+  buildRefundNameBidTransaction,
+  buildRevealNameBidTransaction,
+  buildSettleNameAuctionTransaction,
+  computeNameBidCommitment,
+  getActiveNameAuctions,
+  getNameAuction,
+  getNameAuctionConfig,
+  submitTransaction,
+  type NameAuction,
+  type NameAuctionConfig,
+} from '@/lib/stellar/names';
+
+const STROOPS_PER_XLM = 10_000_000n;
+
+function parseXlm(value: string): bigint | null {
+  if (!/^(?:0|[1-9]\d*)(?:\.\d{1,7})?$/.test(value.trim())) return null;
+  const [whole, fraction = ''] = value.trim().split('.');
+  return BigInt(whole) * STROOPS_PER_XLM + BigInt(fraction.padEnd(7, '0'));
+}
+
+function formatXlm(stroops: bigint) {
+  const whole = stroops / STROOPS_PER_XLM;
+  const fraction = (stroops % STROOPS_PER_XLM).toString().padStart(7, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction} XLM` : `${whole} XLM`;
+}
+
+function formatEndsAt(timestamp: number) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(timestamp * 1000));
+}
+
+function phaseFor(auction: NameAuction, now: number) {
+  if (auction.settled) return 'settled';
+  if (now < auction.commitEnd) return 'commit';
+  if (now < auction.revealEnd) return 'reveal';
+  return 'ended';
+}
+
+export default function NamesAuctions() {
+  const { address, isConnected, signTransaction } = useStellarWallet();
+  const { stellarMetaAddress } = useStealthKeys();
+  const { isKnownAddress } = useContacts();
+  const { isKnownRecipient } = useNameHistory();
+  const watchedAuctions = useNameWatchlistStore((state) => state.watchedAuctions);
+  const bids = useNameWatchlistStore((state) => state.bids);
+  const watchAuction = useNameWatchlistStore((state) => state.watchAuction);
+  const unwatchAuction = useNameWatchlistStore((state) => state.unwatchAuction);
+  const saveBid = useNameWatchlistStore((state) => state.saveBid);
+  const markBidRevealed = useNameWatchlistStore((state) => state.markBidRevealed);
+  const removeBid = useNameWatchlistStore((state) => state.removeBid);
+
+  const [auctions, setAuctions] = useState<NameAuction[]>([]);
+  const [config, setConfig] = useState<NameAuctionConfig | null>(null);
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+  const [isLoading, setIsLoading] = useState(true);
+  const [pendingAction, setPendingAction] = useState('');
+  const [error, setError] = useState('');
+  const [txHash, setTxHash] = useState('');
+  const [lookupName, setLookupName] = useState('');
+  const [selectedAuction, setSelectedAuction] = useState<NameAuction | null>(null);
+  const [bidAmount, setBidAmount] = useState('');
+
+  const trackedNames = useMemo(
+    () => [...new Set([...watchedAuctions.map((item) => item.name), ...Object.keys(bids)])],
+    [bids, watchedAuctions],
+  );
+  const trackedNamesKey = trackedNames.join('|');
+  const isUnknownContract =
+    !isKnownAddress(NAMES_CONTRACT_ID) && !isKnownRecipient(NAMES_CONTRACT_ID);
+
+  const refreshAuctions = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+    try {
+      const [nextAuctions, nextConfig] = await Promise.all([
+        getActiveNameAuctions(trackedNames),
+        getNameAuctionConfig(),
+      ]);
+      setAuctions(nextAuctions.sort((a, b) => a.revealEnd - b.revealEnd));
+      setConfig(nextConfig);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load auctions');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [trackedNamesKey]);
+
+  useEffect(() => {
+    void refreshAuctions();
+  }, [refreshAuctions]);
+
+  useEffect(() => {
+    const timer = globalThis.setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30_000);
+    return () => globalThis.clearInterval(timer);
+  }, []);
+
+  const trackAuction = async () => {
+    const name = lookupName
+      .trim()
+      .toLowerCase()
+      .replace(/\.wraith$/, '');
+    if (!name) return;
+    setPendingAction(`track:${name}`);
+    setError('');
+    try {
+      const auction = await getNameAuction(name);
+      if (!auction) throw new Error(`No auction exists for ${name}.wraith`);
+      watchAuction({ name: auction.name, endsAt: auction.revealEnd });
+      setLookupName('');
+    } catch (trackError) {
+      setError(trackError instanceof Error ? trackError.message : 'Failed to find auction');
+    } finally {
+      setPendingAction('');
+    }
+  };
+
+  const submitAuctionTransaction = async (action: string, buildXdr: () => Promise<string>) => {
+    setPendingAction(action);
+    setError('');
+    setTxHash('');
+    try {
+      const xdr = await buildXdr();
+      const signedXdr = await signTransaction(xdr);
+      const hash = await submitTransaction(signedXdr);
+      setTxHash(hash);
+      await refreshAuctions();
+      return true;
+    } catch (transactionError) {
+      setError(transactionError instanceof Error ? transactionError.message : 'Transaction failed');
+      return false;
+    } finally {
+      setPendingAction('');
+    }
+  };
+
+  const minimumBid = selectedAuction
+    ? [
+        config?.reservePrice ?? 0n,
+        selectedAuction.highestAmount > 0n
+          ? selectedAuction.highestAmount + (config?.minBidIncrement ?? MIN_AUCTION_BID_INCREMENT)
+          : 0n,
+      ].reduce((highest, value) => (value > highest ? value : highest), 0n)
+    : 0n;
+  const parsedBid = parseXlm(bidAmount);
+  const bidError =
+    bidAmount && parsedBid === null
+      ? 'Enter an XLM amount with no more than 7 decimal places.'
+      : parsedBid !== null && parsedBid < minimumBid
+        ? `Minimum bid is ${formatXlm(minimumBid)}.`
+        : '';
+
+  const placeBid = async () => {
+    if (!address || !selectedAuction || parsedBid === null || bidError) return;
+    const action = `bid:${selectedAuction.name}`;
+    setPendingAction(action);
+    setError('');
+    try {
+      const salt = globalThis.crypto.getRandomValues(new Uint8Array(32));
+      const saltHex = Array.from(salt, (byte) => byte.toString(16).padStart(2, '0')).join('');
+      const commitmentHex = await computeNameBidCommitment(
+        address,
+        selectedAuction.name,
+        parsedBid,
+        saltHex,
+      );
+      const submitted = await submitAuctionTransaction(action, () =>
+        buildCommitNameBidTransaction(address, {
+          name: selectedAuction.name,
+          commitmentHex,
+          deposit: parsedBid,
+        }),
+      );
+      if (submitted) {
+        saveBid({
+          name: selectedAuction.name,
+          amountStroops: parsedBid.toString(),
+          depositStroops: parsedBid.toString(),
+          saltHex,
+          revealed: false,
+        });
+        watchAuction({ name: selectedAuction.name, endsAt: selectedAuction.revealEnd });
+        setSelectedAuction(null);
+        setBidAmount('');
+      }
+    } catch (commitmentError) {
+      setError(
+        commitmentError instanceof Error ? commitmentError.message : 'Failed to prepare bid',
+      );
+    } finally {
+      setPendingAction('');
+    }
+  };
+
+  const revealBid = async (auction: NameAuction) => {
+    if (!address) return;
+    const bid = bids[auction.name];
+    if (!bid) return;
+    const submitted = await submitAuctionTransaction(`reveal:${auction.name}`, () =>
+      buildRevealNameBidTransaction(address, {
+        name: auction.name,
+        amount: BigInt(bid.amountStroops),
+        saltHex: bid.saltHex,
+      }),
+    );
+    if (submitted) markBidRevealed(auction.name);
+  };
+
+  const settleAuction = async (auction: NameAuction) => {
+    if (!address) return;
+    await submitAuctionTransaction(`settle:${auction.name}`, () =>
+      buildSettleNameAuctionTransaction(address, auction.name),
+    );
+  };
+
+  const claimName = async (auction: NameAuction) => {
+    if (!address || !stellarMetaAddress) {
+      setError('Derive your Stellar stealth keys before claiming this name.');
+      return;
+    }
+    const decoded = decodeStealthMetaAddress(stellarMetaAddress);
+    const metaAddress = new Uint8Array(64);
+    metaAddress.set(decoded.spendingPubKey, 0);
+    metaAddress.set(decoded.viewingPubKey, 32);
+    const submitted = await submitAuctionTransaction(`claim:${auction.name}`, () =>
+      buildClaimAuctionNameTransaction(address, auction.name, metaAddress),
+    );
+    if (submitted) removeBid(auction.name);
+  };
+
+  const refundBid = async (auction: NameAuction) => {
+    if (!address) return;
+    const submitted = await submitAuctionTransaction(`refund:${auction.name}`, () =>
+      buildRefundNameBidTransaction(address, auction.name),
+    );
+    if (submitted) removeBid(auction.name);
+  };
+
+  if (!isConnected) {
+    return (
+      <section className="flex flex-col gap-3">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          Stellar / Names / Auctions
+        </span>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          Name Auctions
+        </h1>
+        <p className="font-body text-sm text-on-surface-variant">
+          Connect your Stellar wallet to bid on premium Wraith Names.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="flex flex-col gap-2">
+        <Link
+          to="/names"
+          className="font-mono text-[10px] uppercase tracking-widest text-outline hover:text-primary"
+        >
+          Stellar / Names / Auctions
+        </Link>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          Name Auctions
+        </h1>
+        <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+          Bid privately during the commit phase, reveal your bid, then claim the name or refund your
+          deposit after the auction.
+        </p>
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          value={lookupName}
+          onChange={(event) =>
+            setLookupName(event.target.value.toLowerCase().replace(/[^a-z0-9.-]/g, ''))
+          }
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') void trackAuction();
+          }}
+          placeholder="Find a premium name auction"
+          className="h-11 flex-1 border border-outline-variant bg-surface px-3 font-mono text-sm text-primary placeholder:text-outline"
+        />
+        <button
+          type="button"
+          onClick={trackAuction}
+          disabled={!lookupName || pendingAction.startsWith('track:')}
+          className="h-11 border border-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-primary disabled:opacity-30"
+        >
+          Track
+        </button>
+      </div>
+
+      {error && (
+        <p role="alert" className="font-body text-sm text-error">
+          {error}
+        </p>
+      )}
+      {txHash && (
+        <p className="font-body text-sm text-tertiary">
+          Transaction submitted.{' '}
+          <a
+            href={stellarTxUrl(txHash)}
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono underline"
+          >
+            View transaction
+          </a>
+        </p>
+      )}
+
+      <div className="flex flex-col gap-3">
+        {isLoading ? (
+          <p className="font-mono text-xs text-outline">Loading auctions...</p>
+        ) : auctions.length === 0 ? (
+          <div className="border border-outline-variant bg-surface-container p-6 text-center">
+            <p className="font-body text-sm text-on-surface-variant">
+              Track a premium name to see its active auction.
+            </p>
+          </div>
+        ) : (
+          auctions.map((auction) => {
+            const phase = phaseFor(auction, now);
+            const bid = bids[auction.name];
+            const isWinner = auction.highestBidder === address;
+            const isWatched = watchedAuctions.some((item) => item.name === auction.name);
+            return (
+              <article
+                key={auction.name}
+                className="border border-outline-variant bg-surface-container p-4 sm:p-5"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="font-heading text-lg font-semibold text-on-surface">
+                      {auction.name}.wraith
+                    </h2>
+                    <span className="font-mono text-[10px] uppercase tracking-widest text-tertiary">
+                      {phase}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      isWatched
+                        ? unwatchAuction(auction.name)
+                        : watchAuction({ name: auction.name, endsAt: auction.revealEnd })
+                    }
+                    className="font-heading text-[10px] uppercase tracking-widest text-primary"
+                    aria-pressed={isWatched}
+                  >
+                    {isWatched ? 'Watching' : 'Watch'}
+                  </button>
+                </div>
+
+                <dl className="mt-4 grid grid-cols-1 gap-3 border-t border-outline-variant/40 pt-4 sm:grid-cols-3">
+                  <div>
+                    <dt className="font-mono text-[9px] uppercase tracking-widest text-outline">
+                      Top bid
+                    </dt>
+                    <dd className="mt-1 font-mono text-xs text-on-surface">
+                      {auction.highestAmount ? formatXlm(auction.highestAmount) : 'Not revealed'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[9px] uppercase tracking-widest text-outline">
+                      Ends at
+                    </dt>
+                    <dd className="mt-1 font-mono text-xs text-on-surface">
+                      {formatEndsAt(auction.revealEnd)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="font-mono text-[9px] uppercase tracking-widest text-outline">
+                      Your bid
+                    </dt>
+                    <dd className="mt-1 font-mono text-xs text-on-surface">
+                      {bid ? formatXlm(BigInt(bid.amountStroops)) : '—'}
+                    </dd>
+                  </div>
+                </dl>
+
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {phase === 'commit' && !bid && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedAuction(auction);
+                        setBidAmount('');
+                      }}
+                      className="h-9 bg-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-surface"
+                    >
+                      Place bid
+                    </button>
+                  )}
+                  {phase === 'commit' && bid && (
+                    <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                      Bid committed — return to reveal it
+                    </span>
+                  )}
+                  {phase === 'reveal' && bid && !bid.revealed && (
+                    <button
+                      type="button"
+                      onClick={() => void revealBid(auction)}
+                      disabled={pendingAction === `reveal:${auction.name}`}
+                      className="h-9 bg-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-surface disabled:opacity-40"
+                    >
+                      {pendingAction === `reveal:${auction.name}` ? 'Revealing...' : 'Reveal bid'}
+                    </button>
+                  )}
+                  {phase === 'ended' && (
+                    <button
+                      type="button"
+                      onClick={() => void settleAuction(auction)}
+                      disabled={pendingAction === `settle:${auction.name}`}
+                      className="h-9 border border-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-primary disabled:opacity-40"
+                    >
+                      {pendingAction === `settle:${auction.name}`
+                        ? 'Settling...'
+                        : 'Settle auction'}
+                    </button>
+                  )}
+                  {phase === 'settled' && isWinner && (
+                    <button
+                      type="button"
+                      onClick={() => void claimName(auction)}
+                      disabled={pendingAction === `claim:${auction.name}`}
+                      className="h-9 bg-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-surface disabled:opacity-40"
+                    >
+                      {pendingAction === `claim:${auction.name}` ? 'Claiming...' : 'Claim name'}
+                    </button>
+                  )}
+                  {(phase === 'ended' || phase === 'settled') && bid && !isWinner && (
+                    <button
+                      type="button"
+                      onClick={() => void refundBid(auction)}
+                      disabled={pendingAction === `refund:${auction.name}`}
+                      className="h-9 border border-primary px-4 font-heading text-[10px] font-semibold uppercase tracking-widest text-primary disabled:opacity-40"
+                    >
+                      {pendingAction === `refund:${auction.name}` ? 'Refunding...' : 'Refund bid'}
+                    </button>
+                  )}
+                </div>
+              </article>
+            );
+          })
+        )}
+      </div>
+
+      {selectedAuction && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="place-bid-title"
+        >
+          <div className="w-full max-w-md border border-outline-variant bg-surface p-5 sm:p-6">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2
+                  id="place-bid-title"
+                  className="font-heading text-lg font-semibold uppercase tracking-wider text-on-surface"
+                >
+                  Place bid
+                </h2>
+                <p className="mt-1 font-mono text-xs text-outline">{selectedAuction.name}.wraith</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedAuction(null)}
+                className="text-xl text-outline hover:text-primary"
+                aria-label="Close bid modal"
+              >
+                ×
+              </button>
+            </div>
+
+            <label className="mt-5 block font-mono text-[10px] uppercase tracking-widest text-outline">
+              Bid amount (XLM)
+            </label>
+            <input
+              autoFocus
+              inputMode="decimal"
+              value={bidAmount}
+              onChange={(event) => setBidAmount(event.target.value)}
+              placeholder="0.0"
+              aria-invalid={Boolean(bidError)}
+              className="mt-2 h-12 w-full border border-outline-variant bg-surface-container px-4 font-heading text-xl text-primary"
+            />
+            <p className={`mt-2 font-mono text-[10px] ${bidError ? 'text-error' : 'text-outline'}`}>
+              {bidError || `Minimum bid: ${formatXlm(minimumBid)}`}
+            </p>
+
+            {isUnknownContract && (
+              <div className="mt-4 flex items-start gap-2 border border-outline-variant/50 bg-surface-container p-4">
+                <span aria-hidden="true">⚠️</span>
+                <div>
+                  <p className="text-sm font-medium text-on-surface">
+                    You haven't paid this recipient before
+                  </p>
+                  <p className="mt-1 text-xs text-on-surface-variant">
+                    This bid sends funds to the Wraith Names contract. Verify the contract and
+                    network before approving the transaction.
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <p className="mt-4 font-body text-xs leading-relaxed text-outline">
+              Your amount and recovery secret stay in this browser until reveal. Clearing site data
+              before revealing can make the bid unrecoverable.
+            </p>
+
+            {error && (
+              <p role="alert" className="mt-4 font-body text-sm text-error">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="button"
+              onClick={() => void placeBid()}
+              disabled={
+                parsedBid === null ||
+                Boolean(bidError) ||
+                pendingAction === `bid:${selectedAuction.name}`
+              }
+              className="mt-5 h-11 w-full bg-primary font-heading text-[11px] font-semibold uppercase tracking-widest text-surface disabled:opacity-30"
+            >
+              {pendingAction === `bid:${selectedAuction.name}`
+                ? 'Confirm in wallet...'
+                : 'Place bid'}
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/store/nameWatchlistStore.test.ts
+++ b/src/store/nameWatchlistStore.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+describe('name auction watchlist', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    const storage = new MemoryStorage();
+    vi.stubGlobal('localStorage', storage);
+    vi.stubGlobal('window', { localStorage: storage });
+  });
+
+  it('restores watched auctions and sealed bid recovery data', async () => {
+    const { useNameWatchlistStore } = await import('./nameWatchlistStore');
+    const store = useNameWatchlistStore.getState();
+    store.watchAuction({ name: 'NOVA', endsAt: 1_800_000_000 });
+    store.saveBid({
+      name: 'NOVA',
+      amountStroops: '25000000',
+      depositStroops: '25000000',
+      saltHex: 'ab'.repeat(32),
+      revealed: false,
+    });
+
+    const persisted = localStorage.getItem('wraith-name-auction-watchlist');
+    expect(persisted).not.toBeNull();
+    useNameWatchlistStore.setState({ watchedAuctions: [], bids: {} });
+    localStorage.setItem('wraith-name-auction-watchlist', persisted!);
+    await useNameWatchlistStore.persist.rehydrate();
+
+    expect(useNameWatchlistStore.getState().watchedAuctions).toEqual([
+      { name: 'nova', endsAt: 1_800_000_000 },
+    ]);
+    expect(useNameWatchlistStore.getState().bids.nova).toMatchObject({
+      amountStroops: '25000000',
+      saltHex: 'ab'.repeat(32),
+      revealed: false,
+    });
+  });
+});

--- a/src/store/nameWatchlistStore.tsx
+++ b/src/store/nameWatchlistStore.tsx
@@ -1,0 +1,71 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface WatchedNameAuction {
+  name: string;
+  endsAt: number;
+}
+
+export interface LocalAuctionBid {
+  name: string;
+  amountStroops: string;
+  depositStroops: string;
+  saltHex: string;
+  revealed: boolean;
+}
+
+interface NameWatchlistState {
+  watchedAuctions: WatchedNameAuction[];
+  bids: Record<string, LocalAuctionBid>;
+  watchAuction: (auction: WatchedNameAuction) => void;
+  unwatchAuction: (name: string) => void;
+  saveBid: (bid: LocalAuctionBid) => void;
+  markBidRevealed: (name: string) => void;
+  removeBid: (name: string) => void;
+}
+
+const normalizeName = (name: string) => name.trim().toLowerCase();
+
+export const useNameWatchlistStore = create<NameWatchlistState>()(
+  persist(
+    (set) => ({
+      watchedAuctions: [],
+      bids: {},
+      watchAuction: (auction) =>
+        set((state) => {
+          const name = normalizeName(auction.name);
+          return {
+            watchedAuctions: [
+              ...state.watchedAuctions.filter((item) => item.name !== name),
+              { ...auction, name },
+            ],
+          };
+        }),
+      unwatchAuction: (name) =>
+        set((state) => ({
+          watchedAuctions: state.watchedAuctions.filter(
+            (item) => item.name !== normalizeName(name),
+          ),
+        })),
+      saveBid: (bid) =>
+        set((state) => {
+          const name = normalizeName(bid.name);
+          return { bids: { ...state.bids, [name]: { ...bid, name } } };
+        }),
+      markBidRevealed: (name) =>
+        set((state) => {
+          const key = normalizeName(name);
+          const bid = state.bids[key];
+          if (!bid) return state;
+          return { bids: { ...state.bids, [key]: { ...bid, revealed: true } } };
+        }),
+      removeBid: (name) =>
+        set((state) => {
+          const bids = { ...state.bids };
+          delete bids[normalizeName(name)];
+          return { bids };
+        }),
+    }),
+    { name: 'wraith-name-auction-watchlist' },
+  ),
+);


### PR DESCRIPTION
 ## Summary

  Adds a complete UI for Wraith Names auctions, allowing users to bid, monitor, settle, claim, and refund auction positions without using
  the CLI.

  ## Changes

  - Adds the /names/auctions route for active auctions
  - Displays auction name, highest revealed bid, end time in the user’s locale, and the user’s bid
  - Adds a place-bid modal with client-side minimum-increment validation
  - Supports the contract’s sealed-bid commit/reveal flow
  - Reuses the shared unknown-recipient warning before funding bids
  - Adds post-auction settlement actions:
      - Claim the name for the winning bidder
      - Withdraw/refund eligible bids

  - Adds a persistent client-side auction watchlist
  - Shows a Names-page banner when watched auctions end within 24 hours
  - Persists bid recovery data across reloads
  - Supports overriding the names contract through VITE_WRAITH_NAMES_CONTRACT_ID

  ## Testing

  - pnpm run build
  - pnpm exec tsc --noEmit
  - pnpm exec vitest run src/store/nameWatchlistStore.test.ts
  - Targeted Prettier validation
  - Verified /names/auctions renders without runtime errors

closes #153