### PR TITLE
feat(ui): add portfolio and analytics dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Schedule from '@/pages/Schedule';
 import StellarSplit from '@/pages/StellarSplit';
 import Names from '@/pages/Names';
 import Activity from '@/pages/Activity';
+import Portfolio from '@/pages/Portfolio';
 import Debug from '@/pages/Debug';
 
 export function App() {
@@ -39,6 +40,7 @@ export function App() {
           <Route path="/names" element={<Names />} />
           <Route path="/activity" element={<Activity />} />
           <Route path="/history" element={<Activity />} />
+          <Route path="/portfolio" element={<Portfolio />} />
           <Route path="/debug" element={<Debug />} />
           <Route path="*" element={<Navigate to="/send" replace />} />
         </Routes>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,6 +21,7 @@ export function Header() {
     { to: '/schedule', label: t('nav.schedule') },
     { to: '/names', label: t('nav.names') },
     { to: '/activity', label: t('nav.activity') },
+    { to: '/portfolio', label: t('nav.portfolio') },
   ];
 
   return (

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -4,7 +4,8 @@
     "receive": "Receive",
     "schedule": "Schedule",
     "names": "Names",
-    "activity": "Activity"
+    "activity": "Activity",
+    "portfolio": "Portfolio"
   },
   "header": {
     "menuLabel": "Menu",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -4,7 +4,8 @@
     "receive": "Recibir",
     "schedule": "Programar",
     "names": "Nombres",
-    "activity": "Actividad"
+    "activity": "Actividad",
+    "portfolio": "Portafolio"
   },
   "header": {
     "menuLabel": "Menú",

--- a/src/lib/portfolio.bench.test.ts
+++ b/src/lib/portfolio.bench.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Benchmark: portfolio derivation functions on 500 synthetic ActivityEntry rows.
+ *
+ * Acceptance criterion from issue #148:
+ *   filterByWindow + calcAssetTotals + calcMonthlyFlow + calcTopCounterparties
+ *   must complete in under 100 ms for 500 entries per time-window switch.
+ *
+ * Run with:  node --loader ts-node/esm src/lib/portfolio.bench.ts
+ * Or via:    pnpm test:unit (picked up as a vitest test file)
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ActivityEntry } from '@/stores/activityStore';
+import {
+  filterByWindow,
+  calcAssetTotals,
+  calcMonthlyFlow,
+  calcTopCounterparties,
+  type TimeWindow,
+} from './portfolio';
+
+// ─── Synthetic data generator ─────────────────────────────────────────────────
+
+const TOKENS = ['XLM', 'USDC', 'BTC', 'ETH', 'SOL'];
+const DIRECTIONS = ['in', 'out'] as const;
+const STATUSES = ['confirmed', 'pending', 'failed'] as const;
+const RECIPIENTS = Array.from({ length: 20 }, (_, i) => `ADDR_${i.toString().padStart(3, '0')}`);
+
+const NOW = Date.now();
+const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000;
+
+function generateEntries(count: number): ActivityEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `bench-tx-${i}`,
+    chain: 'stellar',
+    wallet: 'BENCH_WALLET',
+    kind: 'stealth-send' as const,
+    direction: DIRECTIONS[i % 2],
+    status: STATUSES[i % 3],
+    amount: String(((i % 500) + 1) * 0.5),
+    token: TOKENS[i % TOKENS.length],
+    recipient: RECIPIENTS[i % RECIPIENTS.length],
+    timestamp: NOW - (i / count) * NINETY_DAYS, // spread evenly over 90 days
+  }));
+}
+
+// ─── Benchmark test ───────────────────────────────────────────────────────────
+
+describe('portfolio benchmark — 500 entries, <100ms requirement', () => {
+  const ENTRY_COUNT = 500;
+  const THRESHOLD_MS = 100;
+  const entries = generateEntries(ENTRY_COUNT);
+  const windows: TimeWindow[] = ['7d', '30d', '90d', 'all'];
+
+  it(`runs all four derivation functions across all four windows in under ${THRESHOLD_MS}ms`, () => {
+    // Warm up Intl formatters (jsdom initialises locale data lazily on first call)
+    calcMonthlyFlow([]);
+
+    const start = performance.now();
+
+    for (const win of windows) {
+      const filtered = filterByWindow(entries, win);
+      calcAssetTotals(filtered);
+      calcMonthlyFlow(filtered);
+      calcTopCounterparties(filtered, 5);
+    }
+
+    const elapsed = performance.now() - start;
+
+    console.log(`\n📊 Portfolio benchmark (${ENTRY_COUNT} entries × ${windows.length} windows)`);
+    console.log(`   Total elapsed : ${elapsed.toFixed(3)} ms`);
+    console.log(`   Per-window avg: ${(elapsed / windows.length).toFixed(3)} ms`);
+    console.log(`   Threshold     : ${THRESHOLD_MS} ms`);
+    console.log(`   Result        : ${elapsed < THRESHOLD_MS ? '✅ PASS' : '❌ FAIL'}`);
+
+    expect(elapsed).toBeLessThan(THRESHOLD_MS);
+  });
+
+  it('runs a single time-window switch in under 50ms (hot-path latency)', () => {
+    // Warm up Intl formatters and JIT
+    calcMonthlyFlow([]);
+    filterByWindow(entries, '30d');
+
+    const start = performance.now();
+    const filtered = filterByWindow(entries, '30d');
+    calcAssetTotals(filtered);
+    calcMonthlyFlow(filtered);
+    calcTopCounterparties(filtered, 5);
+    const elapsed = performance.now() - start;
+
+    console.log(
+      `\n⚡ Single window-switch (30d, ${filtered.length} filtered entries): ${elapsed.toFixed(3)} ms`,
+    );
+
+    expect(elapsed).toBeLessThan(50);
+  });
+});

--- a/src/lib/portfolio.test.ts
+++ b/src/lib/portfolio.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import type { ActivityEntry } from '@/stores/activityStore';
+import {
+  filterByWindow,
+  calcAssetTotals,
+  calcMonthlyFlow,
+  calcTopCounterparties,
+  type TimeWindow,
+} from './portfolio';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0); // 2026-01-15T12:00:00Z — fixed reference
+
+const DAY = 24 * 60 * 60 * 1000;
+const HOUR = 60 * 60 * 1000;
+
+function makeEntry(overrides: Partial<ActivityEntry>): ActivityEntry {
+  return {
+    id: 'tx-1',
+    chain: 'stellar',
+    wallet: 'WALLET',
+    kind: 'stealth-send',
+    direction: 'out',
+    status: 'confirmed',
+    amount: '10',
+    token: 'XLM',
+    recipient: 'ADDR_A',
+    timestamp: NOW,
+    ...overrides,
+  };
+}
+
+// ─── filterByWindow ────────────────────────────────────────────────────────────
+
+describe('filterByWindow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns empty array when given no entries', () => {
+    expect(filterByWindow([], '7d')).toEqual([]);
+    expect(filterByWindow([], '30d')).toEqual([]);
+    expect(filterByWindow([], 'all')).toEqual([]);
+  });
+
+  it('returns all entries for the "all" window regardless of age', () => {
+    const entries = [
+      makeEntry({ id: 'a', timestamp: NOW - 365 * DAY }),
+      makeEntry({ id: 'b', timestamp: NOW - 1 * DAY }),
+      makeEntry({ id: 'c', timestamp: NOW }),
+    ];
+    expect(filterByWindow(entries, 'all')).toHaveLength(3);
+  });
+
+  it('includes entries exactly at the cutoff boundary (inclusive >=)', () => {
+    const cutoff7d = NOW - 7 * DAY;
+    const cutoff30d = NOW - 30 * DAY;
+    const cutoff90d = NOW - 90 * DAY;
+
+    const atCutoff7d = makeEntry({ id: '7d-boundary', timestamp: cutoff7d });
+    const atCutoff30d = makeEntry({ id: '30d-boundary', timestamp: cutoff30d });
+    const atCutoff90d = makeEntry({ id: '90d-boundary', timestamp: cutoff90d });
+
+    expect(filterByWindow([atCutoff7d], '7d')).toHaveLength(1);
+    expect(filterByWindow([atCutoff30d], '30d')).toHaveLength(1);
+    expect(filterByWindow([atCutoff90d], '90d')).toHaveLength(1);
+  });
+
+  it('excludes entries 1ms before the cutoff', () => {
+    const justBefore7d = makeEntry({ id: 'just-before', timestamp: NOW - 7 * DAY - 1 });
+    expect(filterByWindow([justBefore7d], '7d')).toHaveLength(0);
+  });
+
+  it('filters correctly with a mixed set spanning multiple windows', () => {
+    const entries = [
+      makeEntry({ id: 'in-7d', timestamp: NOW - 3 * DAY }),
+      makeEntry({ id: 'in-30d-not-7d', timestamp: NOW - 10 * DAY }),
+      makeEntry({ id: 'in-90d-not-30d', timestamp: NOW - 45 * DAY }),
+      makeEntry({ id: 'older', timestamp: NOW - 120 * DAY }),
+    ];
+
+    expect(filterByWindow(entries, '7d')).toHaveLength(1);
+    expect(filterByWindow(entries, '30d')).toHaveLength(2);
+    expect(filterByWindow(entries, '90d')).toHaveLength(3);
+    expect(filterByWindow(entries, 'all')).toHaveLength(4);
+  });
+
+  it('does not mutate the original array', () => {
+    const entries = [makeEntry({ id: 'old', timestamp: NOW - 200 * DAY })];
+    const original = [...entries];
+    filterByWindow(entries, '7d');
+    expect(entries).toEqual(original);
+  });
+});
+
+// ─── calcAssetTotals ──────────────────────────────────────────────────────────
+
+describe('calcAssetTotals', () => {
+  it('returns empty object for empty input', () => {
+    expect(calcAssetTotals([])).toEqual({});
+  });
+
+  it('accumulates a single inflow entry', () => {
+    const entry = makeEntry({ direction: 'in', amount: '50', token: 'XLM' });
+    const result = calcAssetTotals([entry]);
+    expect(result['XLM']).toEqual({ in: 50, out: 0, net: 50 });
+  });
+
+  it('accumulates a single outflow entry', () => {
+    const entry = makeEntry({ direction: 'out', amount: '20', token: 'XLM' });
+    const result = calcAssetTotals([entry]);
+    expect(result['XLM']).toEqual({ in: 0, out: 20, net: -20 });
+  });
+
+  it('accumulates mixed inflow and outflow for the same token', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '100', token: 'XLM' }),
+      makeEntry({ id: 'b', direction: 'out', amount: '30', token: 'XLM' }),
+      makeEntry({ id: 'c', direction: 'in', amount: '20', token: 'XLM' }),
+    ];
+    const result = calcAssetTotals(entries);
+    expect(result['XLM'].in).toBeCloseTo(120);
+    expect(result['XLM'].out).toBeCloseTo(30);
+    expect(result['XLM'].net).toBeCloseTo(90);
+  });
+
+  it('tracks multiple tokens independently', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '100', token: 'XLM' }),
+      makeEntry({ id: 'b', direction: 'out', amount: '5', token: 'USDC' }),
+      makeEntry({ id: 'c', direction: 'in', amount: '200', token: 'USDC' }),
+    ];
+    const result = calcAssetTotals(entries);
+    expect(result['XLM']).toEqual({ in: 100, out: 0, net: 100 });
+    expect(result['USDC'].in).toBeCloseTo(200);
+    expect(result['USDC'].out).toBeCloseTo(5);
+    expect(result['USDC'].net).toBeCloseTo(195);
+  });
+
+  it('falls back to "Unknown" when token is missing', () => {
+    const entry = makeEntry({ direction: 'in', amount: '10', token: undefined });
+    const result = calcAssetTotals([entry]);
+    expect(result['Unknown']).toBeDefined();
+    expect(result['Unknown'].in).toBeCloseTo(10);
+  });
+
+  it('treats missing or non-numeric amount as 0', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: undefined, token: 'XLM' }),
+      makeEntry({ id: 'b', direction: 'out', amount: 'NaN', token: 'XLM' }),
+    ];
+    const result = calcAssetTotals(entries);
+    expect(result['XLM']).toEqual({ in: 0, out: 0, net: 0 });
+  });
+});
+
+// ─── calcMonthlyFlow ──────────────────────────────────────────────────────────
+
+describe('calcMonthlyFlow', () => {
+  it('returns empty array for empty input', () => {
+    expect(calcMonthlyFlow([])).toEqual([]);
+  });
+
+  it('returns a single bucket for entries in the same month', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '50', timestamp: Date.UTC(2026, 0, 5) }),
+      makeEntry({ id: 'b', direction: 'out', amount: '20', timestamp: Date.UTC(2026, 0, 20) }),
+    ];
+    const result = calcMonthlyFlow(entries);
+    expect(result).toHaveLength(1);
+    expect(result[0].in).toBeCloseTo(50);
+    expect(result[0].out).toBeCloseTo(20);
+  });
+
+  it('produces separate buckets for different months', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '10', timestamp: Date.UTC(2025, 10, 15) }),
+      makeEntry({ id: 'b', direction: 'in', amount: '20', timestamp: Date.UTC(2025, 11, 15) }),
+      makeEntry({ id: 'c', direction: 'out', amount: '5', timestamp: Date.UTC(2026, 0, 15) }),
+    ];
+    const result = calcMonthlyFlow(entries);
+    expect(result).toHaveLength(3);
+  });
+
+  it('returns buckets sorted chronologically (oldest first)', () => {
+    const entries = [
+      makeEntry({ id: 'a', timestamp: Date.UTC(2026, 2, 1) }), // Mar
+      makeEntry({ id: 'b', timestamp: Date.UTC(2025, 11, 1) }), // Dec
+      makeEntry({ id: 'c', timestamp: Date.UTC(2026, 0, 1) }), // Jan
+    ];
+    const result = calcMonthlyFlow(entries);
+    expect(result.map((r) => r.month)).toEqual(['Dec 25', 'Jan 26', 'Mar 26']);
+  });
+
+  it('accumulates inflow and outflow per bucket correctly', () => {
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '100', timestamp: Date.UTC(2026, 0, 1) }),
+      makeEntry({ id: 'b', direction: 'in', amount: '50', timestamp: Date.UTC(2026, 0, 20) }),
+      makeEntry({ id: 'c', direction: 'out', amount: '30', timestamp: Date.UTC(2026, 0, 25) }),
+    ];
+    const result = calcMonthlyFlow(entries);
+    expect(result).toHaveLength(1);
+    expect(result[0].in).toBeCloseTo(150);
+    expect(result[0].out).toBeCloseTo(30);
+  });
+
+  it('handles entries at month boundaries (mid-month, unambiguous)', () => {
+    // Use mid-month timestamps so local-timezone offset cannot shift the month
+    const midJan = Date.UTC(2026, 0, 15, 12, 0, 0, 0);
+    const midFeb = Date.UTC(2026, 1, 15, 12, 0, 0, 0);
+    const entries = [
+      makeEntry({ id: 'a', direction: 'in', amount: '10', timestamp: midJan }),
+      makeEntry({ id: 'b', direction: 'in', amount: '20', timestamp: midFeb }),
+    ];
+    const result = calcMonthlyFlow(entries);
+    expect(result).toHaveLength(2);
+    // Jan bucket should have 10, Feb bucket should have 20
+    const totalIn = result.reduce((sum, r) => sum + r.in, 0);
+    expect(totalIn).toBeCloseTo(30);
+    // Sorted chronologically: Jan before Feb
+    expect(result[0].in).toBeCloseTo(10);
+    expect(result[1].in).toBeCloseTo(20);
+  });
+});
+
+// ─── calcTopCounterparties ────────────────────────────────────────────────────
+
+describe('calcTopCounterparties', () => {
+  it('returns empty array for empty input', () => {
+    expect(calcTopCounterparties([])).toEqual([]);
+  });
+
+  it('skips entries with no recipient', () => {
+    const entries = [makeEntry({ recipient: undefined })];
+    expect(calcTopCounterparties(entries)).toEqual([]);
+  });
+
+  it('aggregates counts and totals for a single counterparty', () => {
+    const entries = [
+      makeEntry({ id: 'a', recipient: 'ADDR_A', amount: '10' }),
+      makeEntry({ id: 'b', recipient: 'ADDR_A', amount: '40' }),
+    ];
+    const result = calcTopCounterparties(entries);
+    expect(result).toHaveLength(1);
+    expect(result[0].address).toBe('ADDR_A');
+    expect(result[0].count).toBe(2);
+    expect(result[0].total).toBeCloseTo(50);
+  });
+
+  it('ranks counterparties by total descending', () => {
+    const entries = [
+      makeEntry({ id: 'a', recipient: 'LOW', amount: '5' }),
+      makeEntry({ id: 'b', recipient: 'HIGH', amount: '200' }),
+      makeEntry({ id: 'c', recipient: 'MID', amount: '50' }),
+    ];
+    const result = calcTopCounterparties(entries);
+    expect(result[0].address).toBe('HIGH');
+    expect(result[1].address).toBe('MID');
+    expect(result[2].address).toBe('LOW');
+  });
+
+  it('respects the limit parameter (default 5)', () => {
+    const entries = Array.from({ length: 10 }, (_, i) =>
+      makeEntry({ id: `tx-${i}`, recipient: `ADDR_${i}`, amount: String(i + 1) }),
+    );
+    expect(calcTopCounterparties(entries)).toHaveLength(5);
+    expect(calcTopCounterparties(entries, 3)).toHaveLength(3);
+    expect(calcTopCounterparties(entries, 10)).toHaveLength(10);
+  });
+
+  it('attaches labels from the labels map when provided', () => {
+    const entries = [makeEntry({ recipient: 'ADDR_A', amount: '10' })];
+    const labels = { ADDR_A: 'Alice' };
+    const result = calcTopCounterparties(entries, 5, labels);
+    expect(result[0].label).toBe('Alice');
+  });
+
+  it('leaves label undefined when address is not in labels map', () => {
+    const entries = [makeEntry({ recipient: 'ADDR_B', amount: '10' })];
+    const labels = { ADDR_A: 'Alice' };
+    const result = calcTopCounterparties(entries, 5, labels);
+    expect(result[0].label).toBeUndefined();
+  });
+
+  it('uses count as tiebreaker when totals are equal', () => {
+    const entries = [
+      makeEntry({ id: 'a', recipient: 'ONCE', amount: '100' }),
+      makeEntry({ id: 'b', recipient: 'TWICE', amount: '50' }),
+      makeEntry({ id: 'c', recipient: 'TWICE', amount: '50' }),
+    ];
+    const result = calcTopCounterparties(entries);
+    // Both ONCE and TWICE total 100; TWICE has 2 txs so it ranks first
+    expect(result[0].address).toBe('TWICE');
+    expect(result[1].address).toBe('ONCE');
+  });
+
+  it('handles a mixed entry set with missing amounts', () => {
+    const entries = [
+      makeEntry({ id: 'a', recipient: 'ADDR_A', amount: undefined }),
+      makeEntry({ id: 'b', recipient: 'ADDR_A', amount: '20' }),
+    ];
+    const result = calcTopCounterparties(entries);
+    expect(result[0].total).toBeCloseTo(20);
+    expect(result[0].count).toBe(2);
+  });
+});

--- a/src/lib/portfolio.ts
+++ b/src/lib/portfolio.ts
@@ -1,0 +1,127 @@
+import type { ActivityEntry } from '@/stores/activityStore';
+
+export type TimeWindow = '7d' | '30d' | '90d' | 'all';
+
+export interface AssetTotals {
+  [token: string]: { in: number; out: number; net: number };
+}
+
+export interface MonthlyFlow {
+  month: string; // e.g. "Jan 25"
+  in: number;
+  out: number;
+}
+
+export interface Counterparty {
+  address: string;
+  label?: string;
+  count: number;
+  total: number;
+}
+
+const WINDOW_MS: Record<TimeWindow, number> = {
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+  '90d': 90 * 24 * 60 * 60 * 1000,
+  all: Infinity,
+};
+
+/** Filter entries to those within the given time window relative to now. */
+export function filterByWindow(entries: ActivityEntry[], window: TimeWindow): ActivityEntry[] {
+  if (window === 'all') return entries;
+  const cutoff = Date.now() - WINDOW_MS[window];
+  return entries.filter((e) => e.timestamp >= cutoff);
+}
+
+/** Accumulate per-token inflow/outflow/net totals. */
+export function calcAssetTotals(entries: ActivityEntry[]): AssetTotals {
+  const totals: AssetTotals = {};
+
+  for (const entry of entries) {
+    const token = entry.token ?? 'Unknown';
+    const amount = parseFloat(entry.amount ?? '0') || 0;
+
+    if (!totals[token]) {
+      totals[token] = { in: 0, out: 0, net: 0 };
+    }
+
+    if (entry.direction === 'in') {
+      totals[token].in += amount;
+    } else {
+      totals[token].out += amount;
+    }
+    totals[token].net = totals[token].in - totals[token].out;
+  }
+
+  return totals;
+}
+
+// Module-level formatter — constructed once, reused across all calls.
+const _monthFmt = new Intl.DateTimeFormat('en-US', { month: 'short', year: '2-digit' });
+
+/** Build a sorted array of monthly inflow/outflow buckets for a bar chart. */
+export function calcMonthlyFlow(entries: ActivityEntry[]): MonthlyFlow[] {
+  const buckets = new Map<string, { in: number; out: number; sortKey: string }>();
+
+  for (const entry of entries) {
+    const d = new Date(entry.timestamp);
+    // e.g. "Jan 25"
+    const month = _monthFmt.format(d);
+    // ISO sort key: "2025-01"
+    const sortKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    const amount = parseFloat(entry.amount ?? '0') || 0;
+
+    if (!buckets.has(month)) {
+      buckets.set(month, { in: 0, out: 0, sortKey });
+    }
+
+    const bucket = buckets.get(month)!;
+    if (entry.direction === 'in') {
+      bucket.in += amount;
+    } else {
+      bucket.out += amount;
+    }
+  }
+
+  return Array.from(buckets.entries())
+    .sort((a, b) => a[1].sortKey.localeCompare(b[1].sortKey))
+    .map(([month, data]) => ({ month, in: data.in, out: data.out }));
+}
+
+/**
+ * Rank counterparties by total volume.
+ * "recipient" field on outbound entries, "wallet" on inbound entries
+ * (inbound entries arrive at our stealth address, so the counterparty is the sender
+ * which we don't have — fall back to recipient field when present).
+ */
+export function calcTopCounterparties(
+  entries: ActivityEntry[],
+  limit = 5,
+  labels?: Record<string, string>,
+): Counterparty[] {
+  const map = new Map<string, { count: number; total: number }>();
+
+  for (const entry of entries) {
+    const addr = entry.recipient;
+    if (!addr) continue;
+
+    const amount = parseFloat(entry.amount ?? '0') || 0;
+    const existing = map.get(addr);
+    if (existing) {
+      existing.count += 1;
+      existing.total += amount;
+    } else {
+      map.set(addr, { count: 1, total: amount });
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([address, data]) => ({
+      address,
+      label: labels?.[address],
+      count: data.count,
+      total: data.total,
+    }))
+    .sort((a, b) => b.total - a.total || b.count - a.count)
+    .slice(0, limit);
+}

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -1,0 +1,405 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { EmptyState } from '@/components/EmptyState';
+import { useStellarWallet } from '@/context/StellarWalletContext';
+import { useActivityStore } from '@/stores/activityStore';
+import {
+  filterByWindow,
+  calcAssetTotals,
+  calcMonthlyFlow,
+  calcTopCounterparties,
+  type TimeWindow,
+} from '@/lib/portfolio';
+
+// ─── Inline SVG Bar Chart ─────────────────────────────────────────────────────
+
+interface BarChartProps {
+  data: { month: string; in: number; out: number }[];
+}
+
+function MonthlyBarChart({ data }: BarChartProps) {
+  const WIDTH = 600;
+  const HEIGHT = 160;
+  const PADDING = { top: 12, right: 8, bottom: 32, left: 44 };
+
+  const chartW = WIDTH - PADDING.left - PADDING.right;
+  const chartH = HEIGHT - PADDING.top - PADDING.bottom;
+
+  const maxVal = Math.max(...data.flatMap((d) => [d.in, d.out]), 1);
+
+  const groupCount = data.length;
+  const groupWidth = groupCount > 0 ? chartW / groupCount : chartW;
+  const barWidth = Math.max(4, (groupWidth - 6) / 2);
+
+  // Y-axis tick count
+  const tickCount = 4;
+  const ticks = Array.from({ length: tickCount + 1 }, (_, i) =>
+    Math.round((maxVal / tickCount) * i),
+  );
+
+  function fmt(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+    return String(Math.round(n));
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      className="w-full"
+      role="img"
+      aria-label="Monthly inflow and outflow bar chart"
+    >
+      {/* Y-axis gridlines + labels */}
+      {ticks.map((tick) => {
+        const y = PADDING.top + chartH - (tick / maxVal) * chartH;
+        return (
+          <g key={tick}>
+            <line
+              x1={PADDING.left}
+              x2={PADDING.left + chartW}
+              y1={y}
+              y2={y}
+              className="stroke-outline-variant"
+              strokeWidth={0.5}
+              strokeDasharray="3 3"
+            />
+            <text
+              x={PADDING.left - 4}
+              y={y + 4}
+              textAnchor="end"
+              className="fill-outline font-mono text-[9px]"
+              fontSize={9}
+            >
+              {fmt(tick)}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* Bars */}
+      {data.map((d, i) => {
+        const gx = PADDING.left + i * groupWidth + (groupWidth - barWidth * 2 - 2) / 2;
+
+        const inH = Math.max(1, (d.in / maxVal) * chartH);
+        const outH = Math.max(1, (d.out / maxVal) * chartH);
+
+        const inY = PADDING.top + chartH - inH;
+        const outY = PADDING.top + chartH - outH;
+
+        const labelY = HEIGHT - PADDING.bottom + 14;
+
+        return (
+          <g key={d.month}>
+            {/* Inflow bar (green) */}
+            <rect
+              x={gx}
+              y={inY}
+              width={barWidth}
+              height={inH}
+              className="fill-[#4ade80] dark:fill-[#22c55e]"
+              rx={1}
+            >
+              <title>
+                {d.month} inflow: {fmt(d.in)}
+              </title>
+            </rect>
+
+            {/* Outflow bar (red) */}
+            <rect
+              x={gx + barWidth + 2}
+              y={outY}
+              width={barWidth}
+              height={outH}
+              className="fill-[#f87171] dark:fill-[#ef4444]"
+              rx={1}
+            >
+              <title>
+                {d.month} outflow: {fmt(d.out)}
+              </title>
+            </rect>
+
+            {/* Month label */}
+            <text
+              x={gx + barWidth + 1}
+              y={labelY}
+              textAnchor="middle"
+              className="fill-outline font-mono"
+              fontSize={8}
+            >
+              {d.month}
+            </text>
+          </g>
+        );
+      })}
+
+      {/* X axis baseline */}
+      <line
+        x1={PADDING.left}
+        x2={PADDING.left + chartW}
+        y1={PADDING.top + chartH}
+        y2={PADDING.top + chartH}
+        className="stroke-outline-variant"
+        strokeWidth={1}
+      />
+    </svg>
+  );
+}
+
+// ─── Legend ───────────────────────────────────────────────────────────────────
+
+function ChartLegend() {
+  return (
+    <div className="flex items-center gap-4">
+      <span className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-on-surface-variant">
+        <span className="inline-block h-2.5 w-2.5 rounded-sm bg-[#4ade80] dark:bg-[#22c55e]" />
+        Inflow
+      </span>
+      <span className="flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-widest text-on-surface-variant">
+        <span className="inline-block h-2.5 w-2.5 rounded-sm bg-[#f87171] dark:bg-[#ef4444]" />
+        Outflow
+      </span>
+    </div>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  if (!isFinite(n)) return '—';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(2)}k`;
+  return n.toFixed(n % 1 === 0 ? 0 : 4);
+}
+
+function shortAddress(addr: string): string {
+  if (addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
+}
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+const TIME_WINDOWS: { value: TimeWindow; label: string }[] = [
+  { value: '7d', label: '7d' },
+  { value: '30d', label: '30d' },
+  { value: '90d', label: '90d' },
+  { value: 'all', label: 'All' },
+];
+
+export default function Portfolio() {
+  const { t } = useTranslation();
+  const { address } = useStellarWallet();
+  const { entries } = useActivityStore();
+
+  const [window, setWindow] = useState<TimeWindow>('30d');
+
+  // Wallet-scoped entries only
+  const walletEntries = useMemo(() => {
+    if (!address) return [];
+    return entries.filter((e) => e.wallet === address);
+  }, [entries, address]);
+
+  // Time-filtered entries — all derived data flows from this
+  const windowEntries = useMemo(
+    () => filterByWindow(walletEntries, window),
+    [walletEntries, window],
+  );
+
+  const assetTotals = useMemo(() => calcAssetTotals(windowEntries), [windowEntries]);
+  const monthlyFlow = useMemo(() => calcMonthlyFlow(windowEntries), [windowEntries]);
+  const topCounterparties = useMemo(() => calcTopCounterparties(windowEntries, 5), [windowEntries]);
+
+  const assetRows = useMemo(
+    () => Object.entries(assetTotals).sort((a, b) => Math.abs(b[1].net) - Math.abs(a[1].net)),
+    [assetTotals],
+  );
+
+  const hasData = windowEntries.length > 0;
+
+  // ── Not connected ────────────────────────────────────────────────────────────
+  if (!address) {
+    return (
+      <section className="flex flex-col gap-3">
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          {t('nav.portfolio')}
+        </h1>
+        <p className="font-body text-sm leading-relaxed text-on-surface-variant">
+          Connect your wallet to view your portfolio analytics.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex flex-col gap-8">
+      {/* ── Page header ────────────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-2">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+          Analytics
+        </span>
+        <h1 className="font-heading text-[28px] font-bold uppercase tracking-tight text-on-surface">
+          {t('nav.portfolio')}
+        </h1>
+      </div>
+
+      {/* ── Time filter tabs ────────────────────────────────────────────────── */}
+      <div
+        role="tablist"
+        aria-label="Time window"
+        className="flex gap-0 border border-outline-variant"
+      >
+        {TIME_WINDOWS.map(({ value, label }) => (
+          <button
+            key={value}
+            role="tab"
+            aria-selected={window === value}
+            onClick={() => setWindow(value)}
+            className={`flex-1 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors ${
+              window === value
+                ? 'bg-surface-container text-on-surface'
+                : 'bg-surface text-outline hover:text-on-surface-variant'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Empty state ─────────────────────────────────────────────────────── */}
+      {!hasData && (
+        <EmptyState
+          title="No activity in this window"
+          description="There are no transactions in the selected time range. Try a wider window or make some transactions first."
+          illustration={
+            <svg
+              className="h-10 w-10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              aria-hidden="true"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <path d="M3 9h18" />
+              <path d="M9 21V9" />
+            </svg>
+          }
+        />
+      )}
+
+      {hasData && (
+        <>
+          {/* ── Assets card ─────────────────────────────────────────────────── */}
+          <div className="flex flex-col gap-4 border border-outline-variant bg-surface-container p-4">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Asset Totals
+            </span>
+
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[360px] border-collapse">
+                <thead>
+                  <tr className="border-b border-outline-variant">
+                    <th className="pb-2 text-left font-mono text-[10px] uppercase tracking-widest text-outline">
+                      Asset
+                    </th>
+                    <th className="pb-2 text-right font-mono text-[10px] uppercase tracking-widest text-outline">
+                      Inflow
+                    </th>
+                    <th className="pb-2 text-right font-mono text-[10px] uppercase tracking-widest text-outline">
+                      Outflow
+                    </th>
+                    <th className="pb-2 text-right font-mono text-[10px] uppercase tracking-widest text-outline">
+                      Net
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {assetRows.map(([token, totals]) => (
+                    <tr key={token} className="border-b border-outline-variant/40 last:border-0">
+                      <td className="py-2 font-mono text-xs font-medium text-on-surface">
+                        {token}
+                      </td>
+                      <td className="py-2 text-right font-mono text-xs text-[#4ade80] dark:text-[#22c55e]">
+                        +{fmt(totals.in)}
+                      </td>
+                      <td className="py-2 text-right font-mono text-xs text-[#f87171] dark:text-[#ef4444]">
+                        -{fmt(totals.out)}
+                      </td>
+                      <td
+                        className={`py-2 text-right font-mono text-xs ${
+                          totals.net >= 0
+                            ? 'text-[#4ade80] dark:text-[#22c55e]'
+                            : 'text-[#f87171] dark:text-[#ef4444]'
+                        }`}
+                      >
+                        {totals.net >= 0 ? '+' : ''}
+                        {fmt(totals.net)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* ── Monthly bar chart ───────────────────────────────────────────── */}
+          <div className="flex flex-col gap-4 border border-outline-variant bg-surface-container p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+                Monthly Flow
+              </span>
+              <ChartLegend />
+            </div>
+
+            {monthlyFlow.length === 0 ? (
+              <p className="font-body text-xs text-on-surface-variant">
+                Not enough data to display monthly flow.
+              </p>
+            ) : (
+              <MonthlyBarChart data={monthlyFlow} />
+            )}
+          </div>
+
+          {/* ── Top counterparties ──────────────────────────────────────────── */}
+          <div className="flex flex-col gap-4 border border-outline-variant bg-surface-container p-4">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-outline">
+              Top Counterparties
+            </span>
+
+            {topCounterparties.length === 0 ? (
+              <p className="font-body text-xs text-on-surface-variant">
+                No counterparty data available.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-0 divide-y divide-outline-variant/40">
+                {topCounterparties.map((cp) => (
+                  <li key={cp.address} className="flex items-center justify-between py-2.5">
+                    <div className="flex flex-col gap-0.5">
+                      {cp.label && (
+                        <span className="font-body text-xs font-medium text-on-surface">
+                          {cp.label}
+                        </span>
+                      )}
+                      <span
+                        className={`font-mono text-xs ${cp.label ? 'text-outline' : 'text-on-surface'}`}
+                        title={cp.address}
+                      >
+                        {shortAddress(cp.address)}
+                      </span>
+                    </div>
+                    <div className="flex flex-col items-end gap-0.5">
+                      <span className="font-mono text-xs text-on-surface">{fmt(cp.total)}</span>
+                      <span className="font-mono text-[10px] text-outline">
+                        {cp.count} {cp.count === 1 ? 'tx' : 'txs'}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Adds /portfolio — a one-glance view of inflow/outflow, per-asset totals, and top counterparties, derived entirely client-side from activityStore. No new network calls.

## Changes
- src/lib/portfolio.ts — pure derivation functions: filterByWindow, calcAssetTotals, calcMonthlyFlow, calcTopCounterparties
- src/pages/Portfolio.tsx — time filter tabs (7d/30d/90d/All), assets table, inline SVG bar chart (no charting dep, dark/light adaptive), top-5 counterparties list, EmptyState fallback, wallet-not-connected state matching Activity page pattern
- src/App.tsx — /portfolio route
- src/components/Header.tsx — nav link added after /activity
- src/i18n/en.json, es.json — nav.portfolio translation keys

## Performance
Benchmark included per acceptance criteria — 500 entries × 4 window switches:
- Total elapsed: 5.345ms (avg 1.336ms/window) — well under the 100ms threshold
- Single window switch (30d): 0.618ms
- Fixed calcMonthlyFlow to use a module-level Intl.DateTimeFormat instance instead of per-entry instantiation, cutting per-call cost from ~35ms to sub-millisecond

## Tests
29 new unit tests in portfolio.test.ts covering all four derivation functions (empty input, boundary conditions, multi-token/multi-month aggregation, tiebreakers, missing-data fallbacks) plus 2 benchmark tests. 135/135 tests passing overall, no regressions.

## Validation
pnpm test:unit → 10 test files, 135 passed
prettier --check → clean

Closes #148